### PR TITLE
Add rememberTesseraState() public API for external state observation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,14 @@ Platform-specific implementations are separated via `expect`/`actual`:
   - Desktop: `DesktopRegionDecoder` (ImageIO, subsample cache)
   - Web: `WasmRegionDecoder` (Skia, full image decode)
 
+### Public State API
+- `TesseraViewerState` — public read-only state holder (`@Stable`, `internal set`)
+- `rememberTesseraState()` — Composable factory (follows `rememberLazyListState()` convention)
+- `TesseraViewerState.sync()` — internal bulk update (called from SideEffect on main thread)
+- `syncViewerState()` — extracted testable function for state synchronization
+- State sync runs in `SideEffect { }` block (not during composition)
+- Optional `state` parameter on all platform `TesseraImage` wrappers
+
 ### No Platform Types in commonMain
 - `android.graphics.Rect` → `TileRect`
 - `android.graphics.Bitmap` → `ImageBitmap`

--- a/README.md
+++ b/README.md
@@ -314,7 +314,38 @@ Three distinct decoding tiers exist across platforms:
 | `enablePagerIntegration` | Boolean | `false` | Pass horizontal swipes to parent Pager |
 | `showScrollIndicators` | Boolean | `false` | Show scroll position indicators when zoomed |
 | `rotation` | ImageRotation | `ImageRotation.None` | User-controlled rotation (None, Rotate90, Rotate180, Rotate270) |
+| `state` | TesseraViewerState? | `null` | Observable viewer state (see below) |
 | `onDismiss` | () -> Unit | `{}` | Dismiss callback |
+
+### State Observation (rememberTesseraState)
+
+Use `rememberTesseraState()` to observe the viewer's internal state from outside the composable:
+
+```kotlin
+val state = rememberTesseraState()
+
+TesseraImage(
+    imageUrl = "https://example.com/large-image.jpg",
+    modifier = Modifier.fillMaxSize(),
+    state = state
+)
+
+// Observe zoom level, loading status, image metadata
+Text("Scale: ${"%.1f".format(state.scale)}x")
+Text("Loading: ${state.isLoading}")
+Text("Tiles cached: ${state.cachedTileCount}")
+state.imageInfo?.let { Text("Size: ${it.width}x${it.height}") }
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `scale` | Float | Current user zoom scale (1.0 = no zoom) |
+| `isLoading` | Boolean | True while downloading and decoding |
+| `imageInfo` | ImageInfo? | Image width, height, mimeType (null until loaded) |
+| `error` | String? | Error message on failure |
+| `zoomLevel` | Int | Current tile zoom level (0-3, -1 before load) |
+| `cachedTileCount` | Int | Number of tiles in memory cache |
+| `isReady` | Boolean | Convenience: loaded successfully, no error |
 
 ### HorizontalPager Integration
 

--- a/sample-desktop/src/desktopMain/kotlin/Main.kt
+++ b/sample-desktop/src/desktopMain/kotlin/Main.kt
@@ -1,5 +1,6 @@
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,12 +13,14 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -27,6 +30,8 @@ import androidx.compose.ui.window.rememberWindowState
 import com.github.bentleypark.tessera.ContentScale
 import com.github.bentleypark.tessera.ImageRotation
 import com.github.bentleypark.tessera.TesseraImage
+import com.github.bentleypark.tessera.TesseraViewerState
+import com.github.bentleypark.tessera.rememberTesseraState
 
 data class TestImage(
     val name: String,
@@ -72,6 +77,7 @@ fun main() = application {
             var selectedIndex by remember { mutableStateOf(0) }
             var currentRotation by remember { mutableStateOf(ImageRotation.None) }
             val image = testImages[selectedIndex]
+            val viewerState = rememberTesseraState()
 
             Surface(modifier = Modifier.fillMaxSize()) {
                 Column(modifier = Modifier.fillMaxSize()) {
@@ -88,7 +94,16 @@ fun main() = application {
                             contentScale = image.contentScale,
                             showScrollIndicators = true,
                             rotation = currentRotation,
+                            state = viewerState,
                             contentDescription = image.name
+                        )
+
+                        // State info overlay
+                        StateInfoOverlay(
+                            viewerState = viewerState,
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(end = 8.dp, bottom = 8.dp)
                         )
                     }
 
@@ -141,6 +156,52 @@ fun main() = application {
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun StateInfoOverlay(
+    viewerState: TesseraViewerState,
+    modifier: Modifier = Modifier
+) {
+    val info = viewerState.imageInfo
+    val statusText = when {
+        viewerState.isLoading -> "Loading..."
+        viewerState.error != null -> "Error"
+        viewerState.isReady -> "Ready"
+        else -> "-"
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.Black.copy(alpha = 0.6f))
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Column {
+            Text(
+                text = statusText,
+                color = if (viewerState.isReady) Color.Green else Color.Yellow,
+                style = MaterialTheme.typography.labelSmall
+            )
+            if (info != null) {
+                Text(
+                    text = "${info.width}x${info.height}",
+                    color = Color.White.copy(alpha = 0.8f),
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+            Text(
+                text = "Zoom: ${((viewerState.scale * 10).toInt() / 10f)}x  Level: ${viewerState.zoomLevel}",
+                color = Color.White.copy(alpha = 0.8f),
+                style = MaterialTheme.typography.labelSmall
+            )
+            Text(
+                text = "Tiles: ${viewerState.cachedTileCount}",
+                color = Color.White.copy(alpha = 0.8f),
+                style = MaterialTheme.typography.labelSmall
+            )
         }
     }
 }

--- a/sample-web/src/wasmJsMain/kotlin/Main.kt
+++ b/sample-web/src/wasmJsMain/kotlin/Main.kt
@@ -1,5 +1,6 @@
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,14 +15,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.CanvasBasedWindow
 import com.github.bentleypark.tessera.ContentScale
 import com.github.bentleypark.tessera.ImageRotation
 import com.github.bentleypark.tessera.TesseraImage
+import com.github.bentleypark.tessera.TesseraViewerState
+import com.github.bentleypark.tessera.rememberTesseraState
 
 data class TestImage(
     val name: String,
@@ -43,6 +51,7 @@ fun main() {
             var selectedIndex by remember { mutableStateOf(0) }
             var currentRotation by remember { mutableStateOf(ImageRotation.None) }
             val image = testImages[selectedIndex]
+            val viewerState = rememberTesseraState()
 
             Surface(modifier = Modifier.fillMaxSize()) {
                 Column(modifier = Modifier.fillMaxSize()) {
@@ -58,7 +67,16 @@ fun main() {
                             contentScale = image.contentScale,
                             showScrollIndicators = true,
                             rotation = currentRotation,
+                            state = viewerState,
                             contentDescription = image.name
+                        )
+
+                        // State info overlay
+                        StateInfoOverlay(
+                            viewerState = viewerState,
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(end = 8.dp, bottom = 8.dp)
                         )
                     }
 
@@ -82,6 +100,53 @@ fun main() {
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun StateInfoOverlay(
+    viewerState: TesseraViewerState,
+    modifier: Modifier = Modifier
+) {
+    val info = viewerState.imageInfo
+    val statusText = when {
+        viewerState.isLoading -> "Loading..."
+        viewerState.error != null -> "Error"
+        viewerState.isReady -> "Ready"
+        else -> "-"
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.Black.copy(alpha = 0.6f))
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Column {
+            Text(
+                text = statusText,
+                color = if (viewerState.isReady) Color.Green else Color.Yellow,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold
+            )
+            if (info != null) {
+                Text(
+                    text = "${info.width}x${info.height}",
+                    color = Color.White.copy(alpha = 0.8f),
+                    fontSize = 10.sp
+                )
+            }
+            Text(
+                text = "Zoom: ${((viewerState.scale * 10).toInt() / 10f)}x  Level: ${viewerState.zoomLevel}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
+            Text(
+                text = "Tiles: ${viewerState.cachedTileCount}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
         }
     }
 }

--- a/sample/src/main/java/com/github/bentleypark/tessera/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/github/bentleypark/tessera/sample/SampleActivity.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.platform.LocalContext
 import com.github.bentleypark.tessera.ContentScale
 import com.github.bentleypark.tessera.ImageRotation
 import com.github.bentleypark.tessera.TesseraImage
+import com.github.bentleypark.tessera.TesseraViewerState
+import com.github.bentleypark.tessera.rememberTesseraState
 import com.github.bentleypark.tessera.coil.CoilImageLoader
 
 private data class TestImage(
@@ -131,6 +133,8 @@ private fun PagerGallery(
     val pagerState = rememberPagerState(initialPage = initialPage) { images.size }
     var currentRotation by remember { mutableStateOf(ImageRotation.None) }
 
+    val viewerState = rememberTesseraState()
+
     Box(modifier = Modifier.fillMaxSize()) {
         HorizontalPager(
             state = pagerState,
@@ -146,10 +150,20 @@ private fun PagerGallery(
                 enablePagerIntegration = isFitMode,
                 showScrollIndicators = true,
                 rotation = currentRotation,
+                state = if (page == pagerState.currentPage) viewerState else null,
                 onDismiss = onBack,
                 contentDescription = images[page].description
             )
         }
+
+        // State info overlay
+        StateInfoOverlay(
+            viewerState = viewerState,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 8.dp, bottom = 16.dp)
+                .zIndex(2f)
+        )
 
         // Page indicator
         Text(
@@ -266,5 +280,52 @@ private fun ImageSelectionScreen(scrollState: ScrollState, onSelect: (Int) -> Un
             color = Color.Gray,
             fontSize = 12.sp
         )
+    }
+}
+
+@Composable
+private fun StateInfoOverlay(
+    viewerState: TesseraViewerState,
+    modifier: Modifier = Modifier
+) {
+    val info = viewerState.imageInfo
+    val statusText = when {
+        viewerState.isLoading -> "Loading..."
+        viewerState.error != null -> "Error"
+        viewerState.isReady -> "Ready"
+        else -> "-"
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.Black.copy(alpha = 0.6f))
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Column {
+            Text(
+                text = statusText,
+                color = if (viewerState.isReady) Color.Green else Color.Yellow,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold
+            )
+            if (info != null) {
+                Text(
+                    text = "${info.width}x${info.height}",
+                    color = Color.White.copy(alpha = 0.8f),
+                    fontSize = 10.sp
+                )
+            }
+            Text(
+                text = "Zoom: ${((viewerState.scale * 10).toInt() / 10f)}x  Level: ${viewerState.zoomLevel}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
+            Text(
+                text = "Tiles: ${viewerState.cachedTileCount}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
+        }
     }
 }

--- a/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/TesseraImage.kt
+++ b/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/TesseraImage.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
  * @param imageLoader Image loading strategy (default: RoutingImageLoader)
  * @param contentDescription Accessibility description
  * @param enableDismissGesture Enable vertical drag-to-dismiss gesture
+ * @param state Observable viewer state created via [rememberTesseraState]
  * @param onDismiss Callback invoked when dismiss gesture is completed
  */
 @Composable
@@ -33,6 +34,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -53,6 +55,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        viewerState = state,
         onDismiss = onDismiss
     )
 }
@@ -61,6 +64,7 @@ fun TesseraImage(
  * Tessera - Compose-native tile-based image viewer for Android resource images
  *
  * @param imageResId Android drawable resource ID (e.g., R.drawable.my_image)
+ * @param state Observable viewer state created via [rememberTesseraState]
  */
 @Composable
 fun TesseraImage(
@@ -75,6 +79,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -96,6 +101,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        viewerState = state,
         onDismiss = onDismiss
     )
 }

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -70,6 +71,7 @@ internal fun TesseraImageContent(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    viewerState: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     var tesseraState by remember { mutableStateOf<TesseraState?>(null) }
@@ -166,6 +168,23 @@ internal fun TesseraImageContent(
                     currentZoomLevel = newZoomLevel
                 }
 
+                // Skip tile loading when not zoomed in and the entire image fits
+                // in the viewport — preview bitmap is sufficient in this case.
+                // FitWidth/FitHeight modes may have scale=1.0 but only show a portion,
+                // so check that the viewport covers the full image dimensions.
+                // viewWidth/viewHeight are in image pixel coordinates (not screen pixels).
+                val vp = state.viewport
+                val info = state.imageInfo
+                if (vp.scale <= zoomThreshold && info != null &&
+                    vp.viewWidth >= info.width.toFloat() - 1f &&
+                    vp.viewHeight >= info.height.toFloat() - 1f
+                ) {
+                    logWarning("TesseraPerf", "skip tiles: preview sufficient " +
+                        "(viewport ${vp.viewWidth.toInt()}x${vp.viewHeight.toInt()} " +
+                        ">= image ${info.width}x${info.height}, scale=${vp.scale})")
+                    return@collect
+                }
+
                 val tilesToLoad = visibleTiles.filter { it.toKey() !in loadedTiles.keys }
 
                 if (tilesToLoad.isEmpty()) {
@@ -230,6 +249,27 @@ internal fun TesseraImageContent(
     DisposableEffect(Unit) {
         onDispose {
             tesseraState?.dispose()
+        }
+    }
+
+    // Sync internal state to public TesseraViewerState after each successful composition.
+    // State reads must happen during composition (not inside SideEffect lambda)
+    // so that Compose subscribes to changes and triggers recomposition.
+    if (viewerState != null) {
+        val syncScale = scale
+        val syncZoomLevel = currentZoomLevel
+        val syncTileCount = tesseraState?.cachedTileCount ?: 0
+        val syncTesseraState = tesseraState
+        val syncLoadError = loadError
+        SideEffect {
+            syncViewerState(
+                vs = viewerState,
+                scale = syncScale,
+                zoomLevel = syncZoomLevel,
+                tileCount = syncTileCount,
+                tesseraState = syncTesseraState,
+                loadError = syncLoadError
+            )
         }
     }
 
@@ -918,4 +958,33 @@ private fun DrawScope.drawMinimap(
         size = Size(viewportW, viewportH),
         style = Stroke(width = borderWidth)
     )
+}
+
+internal fun syncViewerState(
+    vs: TesseraViewerState,
+    scale: Float,
+    zoomLevel: Int,
+    tileCount: Int,
+    tesseraState: TesseraState?,
+    loadError: String?
+) {
+    if (tesseraState != null) {
+        vs.sync(
+            scale = scale,
+            zoomLevel = zoomLevel,
+            cachedTileCount = tileCount,
+            isLoading = tesseraState.isLoading,
+            imageInfo = tesseraState.imageInfo,
+            error = tesseraState.error ?: loadError
+        )
+    } else {
+        vs.sync(
+            scale = scale,
+            zoomLevel = zoomLevel,
+            cachedTileCount = tileCount,
+            isLoading = loadError == null,
+            imageInfo = null,
+            error = loadError
+        )
+    }
 }

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraState.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraState.kt
@@ -2,6 +2,7 @@ package com.github.bentleypark.tessera
 
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -36,6 +37,11 @@ class TesseraState(
     var viewport by mutableStateOf(Viewport())
         private set
     var previewBitmap by mutableStateOf<ImageBitmap?>(null)
+        private set
+
+    /** Number of tiles currently held in the LRU cache. Tracked separately to avoid
+     *  subscribing composition to the entire SnapshotStateMap. */
+    var cachedTileCount by mutableIntStateOf(0)
         private set
 
     /** Synchronous init for testing and simple usage. Must be called on the main thread. */
@@ -185,6 +191,7 @@ class TesseraState(
         evictLRUIfNeeded()
         tileCache[key] = bitmap to coordinate
         updateAccessOrder(key)
+        cachedTileCount = tileCache.size
     }
 
     private fun evictLRUIfNeeded() {
@@ -204,5 +211,6 @@ class TesseraState(
         decoder = null
         tileCache.clear()
         tileCacheAccessOrder.clear()
+        cachedTileCount = 0
     }
 }

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraViewerState.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraViewerState.kt
@@ -1,0 +1,89 @@
+package com.github.bentleypark.tessera
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * Observable state for the Tessera image viewer.
+ *
+ * Use [rememberTesseraState] to create an instance and pass it to [TesseraImage]
+ * to observe zoom level, loading state, image metadata, and other viewer properties
+ * from outside the composable.
+ *
+ * ```kotlin
+ * val state = rememberTesseraState()
+ *
+ * TesseraImage(
+ *     imageUrl = "https://example.com/large-image.jpg",
+ *     state = state
+ * )
+ *
+ * // Observe state externally
+ * Text("Scale: ${state.scale}")
+ * Text("Loading: ${state.isLoading}")
+ * state.imageInfo?.let { Text("Size: ${it.width} x ${it.height}") }
+ * ```
+ */
+@Stable
+class TesseraViewerState {
+    /** Current user zoom scale (1.0 = no zoom). Does not include fitScale. */
+    var scale: Float by mutableFloatStateOf(1f)
+        internal set
+
+    /** True while the image is being downloaded and decoded for the first time. */
+    var isLoading: Boolean by mutableStateOf(true)
+        internal set
+
+    /** Image metadata (width, height, mimeType). Null until loading completes. */
+    var imageInfo: ImageInfo? by mutableStateOf(null)
+        internal set
+
+    /** Error message if image loading or decoding failed. Null on success. */
+    var error: String? by mutableStateOf(null)
+        internal set
+
+    /** Current tile zoom level (0–3). -1 before any tiles are loaded. */
+    var zoomLevel: Int by mutableIntStateOf(-1)
+        internal set
+
+    /** Number of tiles currently cached in memory. */
+    var cachedTileCount: Int by mutableIntStateOf(0)
+        internal set
+
+    /** True when the image has loaded successfully and tiles are being rendered. */
+    val isReady: Boolean
+        get() = !isLoading && error == null && imageInfo != null
+
+    internal fun sync(
+        scale: Float,
+        zoomLevel: Int,
+        cachedTileCount: Int,
+        isLoading: Boolean,
+        imageInfo: ImageInfo?,
+        error: String?
+    ) {
+        this.scale = scale
+        this.zoomLevel = zoomLevel
+        this.cachedTileCount = cachedTileCount
+        this.isLoading = isLoading
+        this.imageInfo = imageInfo
+        this.error = error
+    }
+}
+
+/**
+ * Creates and remembers a [TesseraViewerState] instance.
+ *
+ * Pass the returned state to [TesseraImage] via the `state` parameter,
+ * then observe its properties to react to viewer changes.
+ */
+@Composable
+fun rememberTesseraState(): TesseraViewerState {
+    return remember { TesseraViewerState() }
+}

--- a/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/TesseraViewerStateTest.kt
+++ b/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/TesseraViewerStateTest.kt
@@ -1,0 +1,194 @@
+package com.github.bentleypark.tessera
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TesseraViewerStateTest {
+
+    @Test
+    fun defaultValues() {
+        val state = TesseraViewerState()
+        assertEquals(1f, state.scale)
+        assertTrue(state.isLoading)
+        assertNull(state.imageInfo)
+        assertNull(state.error)
+        assertEquals(-1, state.zoomLevel)
+        assertEquals(0, state.cachedTileCount)
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun isReady_trueWhenLoadedSuccessfully() {
+        val state = TesseraViewerState()
+        state.isLoading = false
+        state.imageInfo = ImageInfo(width = 4000, height = 3000, mimeType = "image/jpeg")
+        state.error = null
+
+        assertTrue(state.isReady)
+    }
+
+    @Test
+    fun isReady_falseWhileLoading() {
+        val state = TesseraViewerState()
+        state.isLoading = true
+        state.imageInfo = ImageInfo(width = 4000, height = 3000)
+
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun isReady_falseOnError() {
+        val state = TesseraViewerState()
+        state.isLoading = false
+        state.error = "decode failed"
+        state.imageInfo = null
+
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun isReady_falseWhenErrorPresentEvenWithImageInfo() {
+        val state = TesseraViewerState()
+        state.isLoading = false
+        state.imageInfo = ImageInfo(width = 4000, height = 3000)
+        state.error = "partial failure"
+
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun isReady_falseWhenImageInfoIsNull() {
+        val state = TesseraViewerState()
+        state.isLoading = false
+        state.error = null
+
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun scaleUpdates() {
+        val state = TesseraViewerState()
+        state.scale = 3.5f
+        assertEquals(3.5f, state.scale)
+    }
+
+    @Test
+    fun zoomLevelUpdates() {
+        val state = TesseraViewerState()
+        state.zoomLevel = 2
+        assertEquals(2, state.zoomLevel)
+    }
+
+    @Test
+    fun cachedTileCountUpdates() {
+        val state = TesseraViewerState()
+        state.cachedTileCount = 42
+        assertEquals(42, state.cachedTileCount)
+    }
+
+    @Test
+    fun imageInfoUpdates() {
+        val state = TesseraViewerState()
+        val info = ImageInfo(width = 8000, height = 6000, mimeType = "image/png")
+        state.imageInfo = info
+        assertEquals(8000, state.imageInfo?.width)
+        assertEquals(6000, state.imageInfo?.height)
+        assertEquals("image/png", state.imageInfo?.mimeType)
+    }
+
+    @Test
+    fun stateCanTransitionBackToLoading() {
+        val state = TesseraViewerState()
+        state.isLoading = false
+        state.imageInfo = ImageInfo(width = 100, height = 100)
+        assertTrue(state.isReady)
+
+        state.isLoading = true
+        state.imageInfo = null
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun syncUpdatesAllFieldsAtomically() {
+        val state = TesseraViewerState()
+        val info = ImageInfo(width = 2000, height = 1500, mimeType = "image/jpeg")
+
+        state.sync(
+            scale = 2.5f,
+            zoomLevel = 1,
+            cachedTileCount = 10,
+            isLoading = false,
+            imageInfo = info,
+            error = null
+        )
+
+        assertEquals(2.5f, state.scale)
+        assertEquals(1, state.zoomLevel)
+        assertEquals(10, state.cachedTileCount)
+        assertFalse(state.isLoading)
+        assertEquals(info, state.imageInfo)
+        assertNull(state.error)
+        assertTrue(state.isReady)
+    }
+
+    @Test
+    fun syncWithError() {
+        val state = TesseraViewerState()
+
+        state.sync(
+            scale = 1f,
+            zoomLevel = -1,
+            cachedTileCount = 0,
+            isLoading = false,
+            imageInfo = null,
+            error = "load failed"
+        )
+
+        assertFalse(state.isLoading)
+        assertNull(state.imageInfo)
+        assertEquals("load failed", state.error)
+        assertFalse(state.isReady)
+    }
+}
+
+class SyncViewerStateTest {
+
+    @Test
+    fun syncWithNullTesseraState_noError() {
+        val vs = TesseraViewerState()
+
+        syncViewerState(
+            vs = vs,
+            scale = 1f,
+            zoomLevel = -1,
+            tileCount = 0,
+            tesseraState = null,
+            loadError = null
+        )
+
+        assertTrue(vs.isLoading)
+        assertNull(vs.imageInfo)
+        assertNull(vs.error)
+    }
+
+    @Test
+    fun syncWithNullTesseraState_withLoadError() {
+        val vs = TesseraViewerState()
+
+        syncViewerState(
+            vs = vs,
+            scale = 1f,
+            zoomLevel = -1,
+            tileCount = 0,
+            tesseraState = null,
+            loadError = "network error"
+        )
+
+        assertFalse(vs.isLoading)
+        assertNull(vs.imageInfo)
+        assertEquals("network error", vs.error)
+    }
+}

--- a/tessera-core/src/desktopMain/kotlin/com/github/bentleypark/tessera/TesseraImage.desktop.kt
+++ b/tessera-core/src/desktopMain/kotlin/com/github/bentleypark/tessera/TesseraImage.desktop.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
  * @param enableDismissGesture Enable vertical drag-to-dismiss gesture
  * @param enablePagerIntegration Enable horizontal swipe pass-through to parent pager
  * @param showScrollIndicators Show scroll position indicators when zoomed
+ * @param state Observable viewer state created via [rememberTesseraState]
  * @param onDismiss Callback invoked when dismiss gesture is completed
  */
 @Composable
@@ -32,6 +33,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     val resolvedLoader = remember(imageLoader) { imageLoader ?: DesktopImageLoader() }
@@ -51,6 +53,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        viewerState = state,
         onDismiss = onDismiss
     )
 }

--- a/tessera-core/src/iosMain/kotlin/com/github/bentleypark/tessera/MainViewController.kt
+++ b/tessera-core/src/iosMain/kotlin/com/github/bentleypark/tessera/MainViewController.kt
@@ -116,6 +116,7 @@ private fun PagerGallery(
 ) {
     val pagerState = rememberPagerState(initialPage = initialPage) { images.size }
     var currentRotation by remember { mutableStateOf(ImageRotation.None) }
+    val viewerState = rememberTesseraState()
 
     Box(modifier = Modifier.fillMaxSize()) {
         HorizontalPager(
@@ -132,10 +133,20 @@ private fun PagerGallery(
                 enablePagerIntegration = isFitMode,
                 showScrollIndicators = true,
                 rotation = currentRotation,
+                state = if (page == pagerState.currentPage) viewerState else null,
                 onDismiss = onBack,
                 contentDescription = images[page].description
             )
         }
+
+        // State info overlay
+        StateInfoOverlay(
+            viewerState = viewerState,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 8.dp, bottom = 16.dp)
+                .zIndex(2f)
+        )
 
         // Page indicator
         Text(
@@ -252,5 +263,52 @@ private fun ImageSelectionScreen(scrollState: ScrollState, onSelect: (Int) -> Un
             color = Color.Gray,
             fontSize = 12.sp
         )
+    }
+}
+
+@Composable
+private fun StateInfoOverlay(
+    viewerState: TesseraViewerState,
+    modifier: Modifier = Modifier
+) {
+    val info = viewerState.imageInfo
+    val statusText = when {
+        viewerState.isLoading -> "Loading..."
+        viewerState.error != null -> "Error"
+        viewerState.isReady -> "Ready"
+        else -> "-"
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.Black.copy(alpha = 0.6f))
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Column {
+            Text(
+                text = statusText,
+                color = if (viewerState.isReady) Color.Green else Color.Yellow,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold
+            )
+            if (info != null) {
+                Text(
+                    text = "${info.width}x${info.height}",
+                    color = Color.White.copy(alpha = 0.8f),
+                    fontSize = 10.sp
+                )
+            }
+            Text(
+                text = "Zoom: ${((viewerState.scale * 10).toInt() / 10f)}x  Level: ${viewerState.zoomLevel}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
+            Text(
+                text = "Tiles: ${viewerState.cachedTileCount}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
+        }
     }
 }

--- a/tessera-core/src/iosMain/kotlin/com/github/bentleypark/tessera/TesseraImage.ios.kt
+++ b/tessera-core/src/iosMain/kotlin/com/github/bentleypark/tessera/TesseraImage.ios.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
  * @param imageLoader Image loading strategy (default: IosImageLoader)
  * @param contentDescription Accessibility description
  * @param enableDismissGesture Enable vertical drag-to-dismiss gesture
+ * @param state Observable viewer state created via [rememberTesseraState]
  * @param onDismiss Callback invoked when dismiss gesture is completed
  */
 @Composable
@@ -30,6 +31,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     val resolvedLoader = remember(imageLoader) { imageLoader ?: IosImageLoader() }
@@ -49,6 +51,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        viewerState = state,
         onDismiss = onDismiss
     )
 }

--- a/tessera-core/src/wasmJsMain/kotlin/com/github/bentleypark/tessera/TesseraImage.wasmJs.kt
+++ b/tessera-core/src/wasmJsMain/kotlin/com/github/bentleypark/tessera/TesseraImage.wasmJs.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
  * @param enableDismissGesture Enable vertical drag-to-dismiss gesture
  * @param enablePagerIntegration Enable horizontal swipe pass-through to parent pager
  * @param showScrollIndicators Show scroll position indicators when zoomed
+ * @param state Observable viewer state created via [rememberTesseraState]
  * @param onDismiss Callback invoked when dismiss gesture is completed
  */
 @Composable
@@ -32,6 +33,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     val resolvedLoader = remember(imageLoader) { imageLoader ?: WasmImageLoader() }
@@ -51,6 +53,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        viewerState = state,
         onDismiss = onDismiss
     )
 }


### PR DESCRIPTION
## Summary

- `TesseraViewerState` — public read-only state holder with `@Stable` annotation
- `rememberTesseraState()` composable factory following Compose conventions (e.g., `rememberLazyListState()`)
- Optional `state` parameter added to `TesseraImage` on all platforms (Android, iOS, Desktop, Web)
- Skip tile loading at zoom level 0 when preview covers full viewport (108MP: 336 tiles / ~252s → 0)
- `StateInfoOverlay` added to all 4 sample apps demonstrating real-time state observation
- 14 unit tests covering defaults, `isReady` edge cases, `sync()`, and `syncViewerState()`

## Observable Properties

| Property | Type | Description |
|----------|------|-------------|
| `scale` | Float | Current user zoom scale (1.0 = no zoom) |
| `isLoading` | Boolean | True while downloading and decoding |
| `imageInfo` | ImageInfo? | Width, height, mimeType (null until loaded) |
| `error` | String? | Error message on failure |
| `zoomLevel` | Int | Current tile zoom level (0-3, -1 before load) |
| `cachedTileCount` | Int | Tiles currently in LRU cache |
| `isReady` | Boolean | Convenience: loaded + no error |

## Usage

```kotlin
val state = rememberTesseraState()

TesseraImage(
    imageUrl = "https://example.com/large.jpg",
    state = state
)

Text("Scale: ${state.scale}x")
Text("Tiles: ${state.cachedTileCount}")
```

## Test plan

- [x] Desktop tests pass (`desktopTest` — 14 new tests)
- [x] Android sample build (`assembleDebug`)
- [x] iOS framework link (`linkDebugFrameworkIosSimulatorArm64`)
- [x] Desktop sample run — state overlay verified
- [x] Android sample run — tile count real-time update verified
- [ ] FitWidth/FitHeight mode — tiles load correctly (not skipped)
- [ ] Zoom in from 1.0x — tiles load on demand

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)