### PR TITLE
Optimize Android tile decoding performance (#42, #43, #44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,17 +138,26 @@ Companion modules (optional):
 tessera-core has zero external image library dependencies.
 
 ### Tile Cache
-- LRU-based (`maxCacheSize` default: 150)
+- LRU-based, `maxCacheSize` auto-scales inversely with tile size: `(150 * 256² / tileSize²).coerceAtLeast(50)`
+- Tile size is dynamic: `(256 * displayDensity).coerceIn(256, 512)` via `LocalDensity`
 - `loadTile()` calls `updateAccessOrder()` to maintain LRU order
 - `evictLRUIfNeeded()` removes the oldest tile when cache is full
+- Android JPEG tiles use `RGB_565` (2 bytes/pixel); PNG/alpha formats use `ARGB_8888`
+- `cachedTileCount` tracked via separate `mutableIntStateOf` (avoids SnapshotStateMap over-subscription)
+
+### Android Decoder Pool
+- `BitmapRegionDecoder` pool (default 2 instances) for parallel tile decoding
+- Each instance retains full encoded image data — pool sizes above 2-3 risk OOM on low-RAM devices
+- `ArrayBlockingQueue` with `poll(5s)` timeout prevents deadlock on `close()`
+- `isClosed` flag ensures in-flight decoders are recycled on return
 
 ### Zoom Levels
-| Level | Scale | Sample Size |
-|-------|-------|-------------|
-| 0 | 1.0x–1.5x | 2 (half resolution) |
-| 1 | 1.5x–3.0x | 1 (full) |
-| 2 | 3.0x–6.0x | 1 |
-| 3 | 6.0x+ | 1 |
+| Level | Scale | Sample Size | Note |
+|-------|-------|-------------|------|
+| 0 | 1.0x–1.5x | 2 (half resolution) | Tiles skipped when viewport covers full image (preview sufficient) |
+| 1 | 1.5x–3.0x | 1 (full) | First level where tiles actually load |
+| 2 | 3.0x–6.0x | 1 | |
+| 3 | 6.0x+ | 1 | |
 
 ## Code Style
 - Follow Kotlin official coding conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,14 @@ Platform-specific implementations are separated via `expect`/`actual`:
   - Desktop: `DesktopRegionDecoder` (ImageIO, subsample cache)
   - Web: `WasmRegionDecoder` (Skia, full image decode)
 
+### Public State API
+- `TesseraViewerState` — public read-only state holder (`@Stable`, `internal set`)
+- `rememberTesseraState()` — Composable factory (follows `rememberLazyListState()` convention)
+- `TesseraViewerState.sync()` — internal bulk update (called from SideEffect on main thread)
+- `syncViewerState()` — extracted testable function for state synchronization
+- State sync runs in `SideEffect { }` block (not during composition)
+- Optional `state` parameter on all platform `TesseraImage` wrappers
+
 ### No Platform Types in commonMain
 - `android.graphics.Rect` → `TileRect`
 - `android.graphics.Bitmap` → `ImageBitmap`

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Three distinct decoding tiers exist across platforms:
 
 ### Memory Protection (iOS / Desktop)
 
-> Android uses `BitmapRegionDecoder` (true partial decode), so no subsampling step is needed — memory stays at tile level (~0.25MB per 256×256 tile) regardless of image size.
+> Android uses `BitmapRegionDecoder` (true partial decode), so no subsampling step is needed — memory stays at tile level regardless of image size. Tile size is dynamic based on display density (256–512px). JPEG tiles use `RGB_565` (2 bytes/pixel, ~128–512KB per tile); PNG and other alpha-capable formats use `ARGB_8888`. A pool of 2 decoder instances enables parallel tile decoding.
 
 | Image Size | Max Subsample | Decoded Resolution | Memory |
 |------------|--------------|-------------------|--------|
@@ -290,12 +290,12 @@ Three distinct decoding tiers exist across platforms:
 
 ### Zoom Levels
 
-| Level | Scale Range | Sample Size | Resolution |
-|-------|-------------|-------------|------------|
-| 0     | 1.0x-1.5x  | 2           | Half       |
-| 1     | 1.5x-3.0x  | 1           | Full       |
-| 2     | 3.0x-6.0x  | 1           | Full       |
-| 3     | 6.0x+      | 1           | Full       |
+| Level | Scale Range | Sample Size | Resolution | Note |
+|-------|-------------|-------------|------------|------|
+| 0     | 1.0x-1.5x  | 2           | Half       | Tiles skipped when preview covers viewport |
+| 1     | 1.5x-3.0x  | 1           | Full       | First level where tiles load |
+| 2     | 3.0x-6.0x  | 1           | Full       | |
+| 3     | 6.0x+      | 1           | Full       | |
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Three distinct decoding tiers exist across platforms:
 | `enablePagerIntegration` | Boolean | `false` | Pass horizontal swipes to parent Pager |
 | `showScrollIndicators` | Boolean | `false` | Show scroll position indicators when zoomed |
 | `rotation` | ImageRotation | `ImageRotation.None` | User-controlled rotation (None, Rotate90, Rotate180, Rotate270) |
+| `tileAnimationDurationMs` | Int | `200` | Tile fade-in/crossfade duration in ms (0 disables animation) |
 | `state` | TesseraViewerState? | `null` | Observable viewer state (see below) |
 | `onDismiss` | () -> Unit | `{}` | Dismiss callback |
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,38 @@ Three distinct decoding tiers exist across platforms:
 | `enablePagerIntegration` | Boolean | `false` | Pass horizontal swipes to parent Pager |
 | `showScrollIndicators` | Boolean | `false` | Show scroll position indicators when zoomed |
 | `rotation` | ImageRotation | `ImageRotation.None` | User-controlled rotation (None, Rotate90, Rotate180, Rotate270) |
+| `state` | TesseraViewerState? | `null` | Observable viewer state (see below) |
 | `onDismiss` | () -> Unit | `{}` | Dismiss callback |
+
+### State Observation (rememberTesseraState)
+
+Use `rememberTesseraState()` to observe the viewer's internal state from outside the composable:
+
+```kotlin
+val state = rememberTesseraState()
+
+TesseraImage(
+    imageUrl = "https://example.com/large-image.jpg",
+    modifier = Modifier.fillMaxSize(),
+    state = state
+)
+
+// Observe zoom level, loading status, image metadata
+Text("Scale: ${"%.1f".format(state.scale)}x")
+Text("Loading: ${state.isLoading}")
+Text("Tiles cached: ${state.cachedTileCount}")
+state.imageInfo?.let { Text("Size: ${it.width}x${it.height}") }
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `scale` | Float | Current user zoom scale (1.0 = no zoom) |
+| `isLoading` | Boolean | True while downloading and decoding |
+| `imageInfo` | ImageInfo? | Image width, height, mimeType (null until loaded) |
+| `error` | String? | Error message on failure |
+| `zoomLevel` | Int | Current tile zoom level (0-3, -1 before load) |
+| `cachedTileCount` | Int | Number of tiles in memory cache |
+| `isReady` | Boolean | Convenience: loaded successfully, no error |
 
 ### HorizontalPager Integration
 

--- a/sample-desktop/src/desktopMain/kotlin/Main.kt
+++ b/sample-desktop/src/desktopMain/kotlin/Main.kt
@@ -1,5 +1,6 @@
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,12 +13,14 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -27,6 +30,8 @@ import androidx.compose.ui.window.rememberWindowState
 import com.github.bentleypark.tessera.ContentScale
 import com.github.bentleypark.tessera.ImageRotation
 import com.github.bentleypark.tessera.TesseraImage
+import com.github.bentleypark.tessera.TesseraViewerState
+import com.github.bentleypark.tessera.rememberTesseraState
 
 data class TestImage(
     val name: String,
@@ -72,6 +77,7 @@ fun main() = application {
             var selectedIndex by remember { mutableStateOf(0) }
             var currentRotation by remember { mutableStateOf(ImageRotation.None) }
             val image = testImages[selectedIndex]
+            val viewerState = rememberTesseraState()
 
             Surface(modifier = Modifier.fillMaxSize()) {
                 Column(modifier = Modifier.fillMaxSize()) {
@@ -88,7 +94,16 @@ fun main() = application {
                             contentScale = image.contentScale,
                             showScrollIndicators = true,
                             rotation = currentRotation,
+                            state = viewerState,
                             contentDescription = image.name
+                        )
+
+                        // State info overlay
+                        StateInfoOverlay(
+                            viewerState = viewerState,
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(end = 8.dp, bottom = 8.dp)
                         )
                     }
 
@@ -141,6 +156,52 @@ fun main() = application {
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun StateInfoOverlay(
+    viewerState: TesseraViewerState,
+    modifier: Modifier = Modifier
+) {
+    val info = viewerState.imageInfo
+    val statusText = when {
+        viewerState.isLoading -> "Loading..."
+        viewerState.error != null -> "Error"
+        viewerState.isReady -> "Ready"
+        else -> "-"
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.Black.copy(alpha = 0.6f))
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Column {
+            Text(
+                text = statusText,
+                color = if (viewerState.isReady) Color.Green else Color.Yellow,
+                style = MaterialTheme.typography.labelSmall
+            )
+            if (info != null) {
+                Text(
+                    text = "${info.width}x${info.height}",
+                    color = Color.White.copy(alpha = 0.8f),
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+            Text(
+                text = "Zoom: ${((viewerState.scale * 10).toInt() / 10f)}x  Level: ${viewerState.zoomLevel}",
+                color = Color.White.copy(alpha = 0.8f),
+                style = MaterialTheme.typography.labelSmall
+            )
+            Text(
+                text = "Tiles: ${viewerState.cachedTileCount}",
+                color = Color.White.copy(alpha = 0.8f),
+                style = MaterialTheme.typography.labelSmall
+            )
         }
     }
 }

--- a/sample-web/src/wasmJsMain/kotlin/Main.kt
+++ b/sample-web/src/wasmJsMain/kotlin/Main.kt
@@ -1,5 +1,6 @@
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,14 +15,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.CanvasBasedWindow
 import com.github.bentleypark.tessera.ContentScale
 import com.github.bentleypark.tessera.ImageRotation
 import com.github.bentleypark.tessera.TesseraImage
+import com.github.bentleypark.tessera.TesseraViewerState
+import com.github.bentleypark.tessera.rememberTesseraState
 
 data class TestImage(
     val name: String,
@@ -43,6 +51,7 @@ fun main() {
             var selectedIndex by remember { mutableStateOf(0) }
             var currentRotation by remember { mutableStateOf(ImageRotation.None) }
             val image = testImages[selectedIndex]
+            val viewerState = rememberTesseraState()
 
             Surface(modifier = Modifier.fillMaxSize()) {
                 Column(modifier = Modifier.fillMaxSize()) {
@@ -58,7 +67,16 @@ fun main() {
                             contentScale = image.contentScale,
                             showScrollIndicators = true,
                             rotation = currentRotation,
+                            state = viewerState,
                             contentDescription = image.name
+                        )
+
+                        // State info overlay
+                        StateInfoOverlay(
+                            viewerState = viewerState,
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(end = 8.dp, bottom = 8.dp)
                         )
                     }
 
@@ -82,6 +100,53 @@ fun main() {
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun StateInfoOverlay(
+    viewerState: TesseraViewerState,
+    modifier: Modifier = Modifier
+) {
+    val info = viewerState.imageInfo
+    val statusText = when {
+        viewerState.isLoading -> "Loading..."
+        viewerState.error != null -> "Error"
+        viewerState.isReady -> "Ready"
+        else -> "-"
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.Black.copy(alpha = 0.6f))
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Column {
+            Text(
+                text = statusText,
+                color = if (viewerState.isReady) Color.Green else Color.Yellow,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold
+            )
+            if (info != null) {
+                Text(
+                    text = "${info.width}x${info.height}",
+                    color = Color.White.copy(alpha = 0.8f),
+                    fontSize = 10.sp
+                )
+            }
+            Text(
+                text = "Zoom: ${((viewerState.scale * 10).toInt() / 10f)}x  Level: ${viewerState.zoomLevel}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
+            Text(
+                text = "Tiles: ${viewerState.cachedTileCount}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
         }
     }
 }

--- a/sample/src/main/java/com/github/bentleypark/tessera/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/github/bentleypark/tessera/sample/SampleActivity.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.platform.LocalContext
 import com.github.bentleypark.tessera.ContentScale
 import com.github.bentleypark.tessera.ImageRotation
 import com.github.bentleypark.tessera.TesseraImage
+import com.github.bentleypark.tessera.TesseraViewerState
+import com.github.bentleypark.tessera.rememberTesseraState
 import com.github.bentleypark.tessera.coil.CoilImageLoader
 
 private data class TestImage(
@@ -131,6 +133,8 @@ private fun PagerGallery(
     val pagerState = rememberPagerState(initialPage = initialPage) { images.size }
     var currentRotation by remember { mutableStateOf(ImageRotation.None) }
 
+    val viewerState = rememberTesseraState()
+
     Box(modifier = Modifier.fillMaxSize()) {
         HorizontalPager(
             state = pagerState,
@@ -146,10 +150,20 @@ private fun PagerGallery(
                 enablePagerIntegration = isFitMode,
                 showScrollIndicators = true,
                 rotation = currentRotation,
+                state = if (page == pagerState.currentPage) viewerState else null,
                 onDismiss = onBack,
                 contentDescription = images[page].description
             )
         }
+
+        // State info overlay
+        StateInfoOverlay(
+            viewerState = viewerState,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 8.dp, bottom = 16.dp)
+                .zIndex(2f)
+        )
 
         // Page indicator
         Text(
@@ -266,5 +280,52 @@ private fun ImageSelectionScreen(scrollState: ScrollState, onSelect: (Int) -> Un
             color = Color.Gray,
             fontSize = 12.sp
         )
+    }
+}
+
+@Composable
+private fun StateInfoOverlay(
+    viewerState: TesseraViewerState,
+    modifier: Modifier = Modifier
+) {
+    val info = viewerState.imageInfo
+    val statusText = when {
+        viewerState.isLoading -> "Loading..."
+        viewerState.error != null -> "Error"
+        viewerState.isReady -> "Ready"
+        else -> "-"
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.Black.copy(alpha = 0.6f))
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Column {
+            Text(
+                text = statusText,
+                color = if (viewerState.isReady) Color.Green else Color.Yellow,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold
+            )
+            if (info != null) {
+                Text(
+                    text = "${info.width}x${info.height}",
+                    color = Color.White.copy(alpha = 0.8f),
+                    fontSize = 10.sp
+                )
+            }
+            Text(
+                text = "Zoom: ${((viewerState.scale * 10).toInt() / 10f)}x  Level: ${viewerState.zoomLevel}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
+            Text(
+                text = "Tiles: ${viewerState.cachedTileCount}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
+        }
     }
 }

--- a/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/ImageDecoder.kt
+++ b/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/ImageDecoder.kt
@@ -10,18 +10,25 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.exifinterface.media.ExifInterface
 import java.io.File
 import java.io.InputStream
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
 
 /**
  * Wrapper for Android's BitmapRegionDecoder to handle tile-based image decoding.
+ * Uses a pool of decoder instances for parallel tile decoding (FileSource only).
  * Automatically handles EXIF orientation for correct display.
  */
 class ImageDecoder(
     private val imageSource: ImageSource,
-    private val tempFileProvider: (String, InputStream) -> File
+    private val tempFileProvider: (String, InputStream) -> File,
+    private val maxDecoderInstances: Int = 2
 ) : RegionDecoder {
-    private var decoder: BitmapRegionDecoder? = null
     private var _imageInfo: ImageInfo? = null
     private var fallbackFile: File? = null
+
+    // Decoder pool for parallel decoding
+    private var decoderPool: ArrayBlockingQueue<BitmapRegionDecoder>? = null
+    private val allDecoders = mutableListOf<BitmapRegionDecoder>()
 
     // EXIF orientation: raw pixel dimensions (before rotation)
     private var rawWidth: Int = 0
@@ -31,7 +38,12 @@ class ImageDecoder(
 
     @Volatile
     private var isDecoderInitialized = false
+    @Volatile
+    private var isClosed = false
     private val decoderLock = Any()
+
+    // File path for creating additional decoder instances
+    private var decoderFilePath: String? = null
 
     override val imageInfo: ImageInfo
         get() = _imageInfo ?: throw IllegalStateException("Decoder not initialized")
@@ -96,14 +108,70 @@ class ImageDecoder(
         synchronized(decoderLock) {
             if (isDecoderInitialized) return
 
-            decoder = createRegionDecoder()
+            // Resolve file path for pool creation
+            val filePath = resolveFilePath()
+            decoderFilePath = filePath
+
+            val poolSize = if (filePath != null) maxDecoderInstances else 1
+            val pool = ArrayBlockingQueue<BitmapRegionDecoder>(poolSize)
+
+            // Create first decoder
+            val firstDecoder = createRegionDecoder()
+            if (firstDecoder != null) {
+                pool.add(firstDecoder)
+                allDecoders.add(firstDecoder)
+            }
+
+            // Create additional decoders from file path (only for FileSource)
+            if (filePath != null && firstDecoder != null) {
+                for (i in 1 until poolSize) {
+                    try {
+                        val extra = createRegionDecoderFromFile(File(filePath))
+                        if (extra != null) {
+                            pool.add(extra)
+                            allDecoders.add(extra)
+                        }
+                    } catch (e: Exception) {
+                        logWarning("ImageDecoder", "Failed to create pool decoder #$i", e)
+                        break
+                    }
+                }
+            }
+
+            decoderPool = pool
             isDecoderInitialized = true
+
+            if (allDecoders.size > 1) {
+                logWarning("TesseraPerf", "decoder pool: ${allDecoders.size} instances")
+            }
         }
+    }
+
+    private fun resolveFilePath(): String? {
+        return when (val source = imageSource) {
+            is ImageSource.FileSource -> source.file.absolutePath
+            is ImageSource.ResourceSource -> {
+                getOrCreateFallbackFile(source.description, source.openStream)?.absolutePath
+            }
+        }
+    }
+
+    private fun acquireDecoder(): BitmapRegionDecoder? {
+        if (isClosed) return null
+        return decoderPool?.poll(5, TimeUnit.SECONDS)
+    }
+
+    private fun releaseDecoder(decoder: BitmapRegionDecoder) {
+        if (isClosed) {
+            decoder.recycle()
+            return
+        }
+        decoderPool?.put(decoder)
     }
 
     override fun decodeTile(rect: TileRect, sampleSize: Int): ImageBitmap? {
         ensureDecoderInitialized()
-        val currentDecoder = decoder ?: return null
+        val currentDecoder = acquireDecoder() ?: return null
 
         return try {
             val format = ImageFormat.fromMimeType(imageInfo.mimeType)
@@ -121,7 +189,7 @@ class ImageDecoder(
             val androidRect = Rect(rawRect.left, rawRect.top, rawRect.right, rawRect.bottom)
             val decoded = currentDecoder.decodeRegion(androidRect, options) ?: return null
 
-            // Apply rotation
+            // Apply rotation (thread-safe, operates on independent bitmap)
             val rotated = applyRotation(decoded)
             if (rotated !== decoded) decoded.recycle()
             rotated.asImageBitmap()
@@ -130,6 +198,8 @@ class ImageDecoder(
         } catch (e: Exception) {
             logError("ImageDecoder", "decodeTile failed: rect=$rect sampleSize=$sampleSize", e)
             null
+        } finally {
+            releaseDecoder(currentDecoder)
         }
     }
 
@@ -173,11 +243,20 @@ class ImageDecoder(
     }
 
     override fun close() {
-        decoder?.recycle()
-        decoder = null
-        isDecoderInitialized = false
-        fallbackFile?.delete()
-        fallbackFile = null
+        synchronized(decoderLock) {
+            isClosed = true
+            // Only recycle decoders currently in the pool.
+            // In-flight decoders will be recycled when returned via releaseDecoder().
+            val remaining = mutableListOf<BitmapRegionDecoder>()
+            decoderPool?.drainTo(remaining)
+            remaining.forEach { it.recycle() }
+            allDecoders.clear()
+            decoderPool = null
+            isDecoderInitialized = false
+            fallbackFile?.delete()
+            fallbackFile = null
+            decoderFilePath = null
+        }
     }
 
     private fun remapRect(rect: TileRect): TileRect {

--- a/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/ImageDecoder.kt
+++ b/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/ImageDecoder.kt
@@ -15,8 +15,15 @@ import java.util.concurrent.TimeUnit
 
 /**
  * Wrapper for Android's BitmapRegionDecoder to handle tile-based image decoding.
- * Uses a pool of decoder instances for parallel tile decoding (FileSource only).
+ * Uses a pool of decoder instances for parallel tile decoding when a file path
+ * is available (FileSource directly, ResourceSource via fallback file).
  * Automatically handles EXIF orientation for correct display.
+ *
+ * Pool size is limited to 2 by default. Each BitmapRegionDecoder instance
+ * retains a reference to the full encoded image data (memory-mapped for files,
+ * heap-buffered for streams). Multiple instances increase native memory pressure,
+ * especially for large images (e.g., a 10MB JPEG may add up to ~10MB per instance).
+ * Pool sizes above 2-3 risk OOM or ANR on low-RAM devices.
  */
 class ImageDecoder(
     private val imageSource: ImageSource,

--- a/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/ImageDecoder.kt
+++ b/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/ImageDecoder.kt
@@ -106,9 +106,14 @@ class ImageDecoder(
         val currentDecoder = decoder ?: return null
 
         return try {
+            val format = ImageFormat.fromMimeType(imageInfo.mimeType)
             val options = BitmapFactory.Options().apply {
                 inSampleSize = sampleSize
-                inPreferredConfig = Bitmap.Config.ARGB_8888
+                inPreferredConfig = if (format == ImageFormat.JPEG) {
+                    Bitmap.Config.RGB_565
+                } else {
+                    Bitmap.Config.ARGB_8888
+                }
             }
 
             // Remap display coordinates to raw pixel coordinates

--- a/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/TesseraImage.kt
+++ b/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/TesseraImage.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
  * @param imageLoader Image loading strategy (default: RoutingImageLoader)
  * @param contentDescription Accessibility description
  * @param enableDismissGesture Enable vertical drag-to-dismiss gesture
+ * @param state Observable viewer state created via [rememberTesseraState]
  * @param onDismiss Callback invoked when dismiss gesture is completed
  */
 @Composable
@@ -33,6 +34,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -53,6 +55,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        viewerState = state,
         onDismiss = onDismiss
     )
 }
@@ -61,6 +64,7 @@ fun TesseraImage(
  * Tessera - Compose-native tile-based image viewer for Android resource images
  *
  * @param imageResId Android drawable resource ID (e.g., R.drawable.my_image)
+ * @param state Observable viewer state created via [rememberTesseraState]
  */
 @Composable
 fun TesseraImage(
@@ -75,6 +79,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -96,6 +101,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        viewerState = state,
         onDismiss = onDismiss
     )
 }

--- a/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/TesseraImage.kt
+++ b/tessera-core/src/androidMain/kotlin/com/github/bentleypark/tessera/TesseraImage.kt
@@ -34,6 +34,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    tileAnimationDurationMs: Int = 200,
     state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
@@ -55,6 +56,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        tileAnimationDurationMs = tileAnimationDurationMs,
         viewerState = state,
         onDismiss = onDismiss
     )
@@ -79,6 +81,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    tileAnimationDurationMs: Int = 200,
     state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
@@ -101,6 +104,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        tileAnimationDurationMs = tileAnimationDurationMs,
         viewerState = state,
         onDismiss = onDismiss
     )

--- a/tessera-core/src/androidUnitTest/kotlin/com/github/bentleypark/tessera/TesseraGestureTest.kt
+++ b/tessera-core/src/androidUnitTest/kotlin/com/github/bentleypark/tessera/TesseraGestureTest.kt
@@ -60,6 +60,7 @@ class TesseraGestureTest {
         enablePagerIntegration: Boolean = false,
         showScrollIndicators: Boolean = false,
         rotation: ImageRotation = ImageRotation.None,
+        tileAnimationDurationMs: Int = 200,
         imageWidth: Int = 2000,
         imageHeight: Int = 1500,
         viewerState: TesseraViewerState? = null,
@@ -77,6 +78,7 @@ class TesseraGestureTest {
                 enablePagerIntegration = enablePagerIntegration,
                 showScrollIndicators = showScrollIndicators,
                 rotation = rotation,
+                tileAnimationDurationMs = tileAnimationDurationMs,
                 viewerState = viewerState,
                 onDismiss = onDismiss
             )
@@ -404,5 +406,57 @@ class TesseraGestureTest {
 
         // Scale should have changed to 3.0 (double-tap zoom target)
         assertTrue(state.scale > 1.0f, "Scale should increase after double-tap zoom")
+    }
+
+    // --- Tile animation tests ---
+
+    @Test
+    fun tileAnimation_defaultDuration_noCrash() {
+        setUpContent(tileAnimationDurationMs = 200)
+        val node = composeTestRule.onNodeWithContentDescription(testContentDescription)
+        node.performTouchInput { doubleClick(center) }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun tileAnimation_disabled_noCrash() {
+        setUpContent(tileAnimationDurationMs = 0)
+        val node = composeTestRule.onNodeWithContentDescription(testContentDescription)
+        node.performTouchInput { doubleClick(center) }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun tileAnimation_longDuration_noCrash() {
+        setUpContent(tileAnimationDurationMs = 1000)
+        val node = composeTestRule.onNodeWithContentDescription(testContentDescription)
+        node.performTouchInput { doubleClick(center) }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun tileAnimation_negativeDuration_treatedAsZero() {
+        // Negative values are clamped to 0 (animation disabled)
+        setUpContent(tileAnimationDurationMs = -1)
+        val node = composeTestRule.onNodeWithContentDescription(testContentDescription)
+        node.performTouchInput { doubleClick(center) }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun tileAnimation_zoomLevelTransition_noCrash() {
+        val state = TesseraViewerState()
+        setUpContent(tileAnimationDurationMs = 200, viewerState = state)
+        composeTestRule.waitForIdle()
+
+        val node = composeTestRule.onNodeWithContentDescription(testContentDescription)
+        // Zoom in (triggers zoom level change → crossfade)
+        node.performTouchInput { doubleClick(center) }
+        composeTestRule.waitForIdle()
+        // Zoom out (triggers reverse transition)
+        node.performTouchInput { doubleClick(center) }
+        composeTestRule.waitForIdle()
+
+        assertTrue(state.isReady, "State should remain ready through zoom transitions")
     }
 }

--- a/tessera-core/src/androidUnitTest/kotlin/com/github/bentleypark/tessera/TesseraGestureTest.kt
+++ b/tessera-core/src/androidUnitTest/kotlin/com/github/bentleypark/tessera/TesseraGestureTest.kt
@@ -11,7 +11,9 @@ import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.swipeDown
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.pinch
 import androidx.compose.ui.test.swipeRight
+import androidx.compose.ui.geometry.Offset
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -60,6 +62,7 @@ class TesseraGestureTest {
         rotation: ImageRotation = ImageRotation.None,
         imageWidth: Int = 2000,
         imageHeight: Int = 1500,
+        viewerState: TesseraViewerState? = null,
         onDismiss: () -> Unit = {}
     ) {
         composeTestRule.setContent {
@@ -74,6 +77,7 @@ class TesseraGestureTest {
                 enablePagerIntegration = enablePagerIntegration,
                 showScrollIndicators = showScrollIndicators,
                 rotation = rotation,
+                viewerState = viewerState,
                 onDismiss = onDismiss
             )
         }
@@ -354,4 +358,51 @@ class TesseraGestureTest {
             .assertExists()
     }
 
+    // --- Gesture pause tests ---
+
+    @Test
+    fun pinchZoom_pausesTileLoading_thenResumesAfterGesture() {
+        val state = TesseraViewerState()
+        setUpContent(viewerState = state, imageWidth = 4000, imageHeight = 3000)
+        composeTestRule.waitForIdle()
+
+        // Record tile count before pinch
+        val tilesBefore = state.cachedTileCount
+
+        // Perform pinch zoom (gesture starts → isGesturing = true)
+        composeTestRule.onNodeWithContentDescription(testContentDescription)
+            .performTouchInput {
+                pinch(
+                    start0 = center - Offset(100f, 0f),
+                    end0 = center - Offset(200f, 0f),
+                    start1 = center + Offset(100f, 0f),
+                    end1 = center + Offset(200f, 0f)
+                )
+            }
+
+        // After gesture ends, wait for tile loading to resume
+        composeTestRule.waitForIdle()
+
+        // Verify no crash during pinch gesture with tile pause logic.
+        // Pinch zoom in Robolectric may not change scale reliably,
+        // so we verify the gesture completes without error.
+        assertTrue(state.isReady, "State should remain ready after pinch gesture")
+    }
+
+    @Test
+    fun viewerState_reflectsStateAfterGesture() {
+        val state = TesseraViewerState()
+        setUpContent(viewerState = state)
+        composeTestRule.waitForIdle()
+
+        assertTrue(state.isReady, "State should be ready after load")
+
+        // Double-tap to zoom in
+        composeTestRule.onNodeWithContentDescription(testContentDescription)
+            .performTouchInput { doubleClick(center) }
+        composeTestRule.waitForIdle()
+
+        // Scale should have changed to 3.0 (double-tap zoom target)
+        assertTrue(state.scale > 1.0f, "Scale should increase after double-tap zoom")
+    }
 }

--- a/tessera-core/src/androidUnitTest/kotlin/com/github/bentleypark/tessera/TesseraStateTest.kt
+++ b/tessera-core/src/androidUnitTest/kotlin/com/github/bentleypark/tessera/TesseraStateTest.kt
@@ -432,4 +432,74 @@ class TesseraStateTest {
         assertTrue(rect.right > 0)
         assertTrue(rect.bottom > 0)
     }
+
+    // --- Dynamic tile size & maxCacheSize ---
+
+    @Test
+    fun tileSize_256_defaultMaxCacheSize150() {
+        val state = TesseraState(dummySource, { FakeRegionDecoder() }, tileSize = 256)
+        state.initialize()
+
+        // Load up to 150 tiles — should all fit
+        (0 until 150).forEach { i ->
+            val coord = TileCoordinate(i % 20, i / 20, 0)
+            state.loadTile(coord)
+        }
+        assertEquals(150, state.cachedTileCount)
+    }
+
+    @Test
+    fun tileSize_512_reducedMaxCacheSize() {
+        // maxCacheSize = (150 * 256*256 / 512*512).coerceAtLeast(50) = 37 → capped at 50
+        val state = TesseraState(dummySource, { FakeRegionDecoder() }, tileSize = 512)
+        state.initialize()
+
+        // Load 60 tiles — should be capped at maxCacheSize (~50)
+        (0 until 60).forEach { i ->
+            val coord = TileCoordinate(i % 20, i / 20, 0)
+            state.loadTile(coord)
+        }
+        assertTrue(state.cachedTileCount <= 50,
+            "Cache should be capped: ${state.cachedTileCount} <= 50")
+    }
+
+    // --- cachedTileCount tracking ---
+
+    @Test
+    fun cachedTileCount_tracksCorrectly() {
+        val (state, _) = createInitializedState()
+
+        assertEquals(0, state.cachedTileCount)
+
+        state.loadTile(TileCoordinate(0, 0, 0))
+        assertEquals(1, state.cachedTileCount)
+
+        state.loadTile(TileCoordinate(1, 0, 0))
+        assertEquals(2, state.cachedTileCount)
+    }
+
+    @Test
+    fun cachedTileCount_decreasesOnEviction() {
+        val (state, _) = createInitializedState(maxCacheSize = 2)
+
+        state.loadTile(TileCoordinate(0, 0, 0))
+        state.loadTile(TileCoordinate(1, 0, 0))
+        assertEquals(2, state.cachedTileCount)
+
+        // Third tile causes eviction
+        state.loadTile(TileCoordinate(2, 0, 0))
+        assertEquals(2, state.cachedTileCount)
+    }
+
+    @Test
+    fun cachedTileCount_resetsOnDispose() {
+        val (state, _) = createInitializedState()
+
+        state.loadTile(TileCoordinate(0, 0, 0))
+        state.loadTile(TileCoordinate(1, 0, 0))
+        assertEquals(2, state.cachedTileCount)
+
+        state.dispose()
+        assertEquals(0, state.cachedTileCount)
+    }
 }

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -70,6 +71,7 @@ internal fun TesseraImageContent(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    viewerState: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     var tesseraState by remember { mutableStateOf<TesseraState?>(null) }
@@ -166,6 +168,23 @@ internal fun TesseraImageContent(
                     currentZoomLevel = newZoomLevel
                 }
 
+                // Skip tile loading when not zoomed in and the entire image fits
+                // in the viewport — preview bitmap is sufficient in this case.
+                // FitWidth/FitHeight modes may have scale=1.0 but only show a portion,
+                // so check that the viewport covers the full image dimensions.
+                // viewWidth/viewHeight are in image pixel coordinates (not screen pixels).
+                val vp = state.viewport
+                val info = state.imageInfo
+                if (vp.scale <= zoomThreshold && info != null &&
+                    vp.viewWidth >= info.width.toFloat() - 1f &&
+                    vp.viewHeight >= info.height.toFloat() - 1f
+                ) {
+                    logWarning("TesseraPerf", "skip tiles: preview sufficient " +
+                        "(viewport ${vp.viewWidth.toInt()}x${vp.viewHeight.toInt()} " +
+                        ">= image ${info.width}x${info.height}, scale=${vp.scale})")
+                    return@collect
+                }
+
                 val tilesToLoad = visibleTiles.filter { it.toKey() !in loadedTiles.keys }
 
                 if (tilesToLoad.isEmpty()) {
@@ -230,6 +249,27 @@ internal fun TesseraImageContent(
     DisposableEffect(Unit) {
         onDispose {
             tesseraState?.dispose()
+        }
+    }
+
+    // Sync internal state to public TesseraViewerState after each successful composition.
+    // State reads must happen during composition (not inside SideEffect lambda)
+    // so that Compose subscribes to changes and triggers recomposition.
+    if (viewerState != null) {
+        val syncScale = scale
+        val syncZoomLevel = currentZoomLevel
+        val syncTileCount = tesseraState?.cachedTileCount ?: 0
+        val syncTesseraState = tesseraState
+        val syncLoadError = loadError
+        SideEffect {
+            syncViewerState(
+                vs = viewerState,
+                scale = syncScale,
+                zoomLevel = syncZoomLevel,
+                tileCount = syncTileCount,
+                tesseraState = syncTesseraState,
+                loadError = syncLoadError
+            )
         }
     }
 
@@ -918,4 +958,33 @@ private fun DrawScope.drawMinimap(
         size = Size(viewportW, viewportH),
         style = Stroke(width = borderWidth)
     )
+}
+
+internal fun syncViewerState(
+    vs: TesseraViewerState,
+    scale: Float,
+    zoomLevel: Int,
+    tileCount: Int,
+    tesseraState: TesseraState?,
+    loadError: String?
+) {
+    if (tesseraState != null) {
+        vs.sync(
+            scale = scale,
+            zoomLevel = zoomLevel,
+            cachedTileCount = tileCount,
+            isLoading = tesseraState.isLoading,
+            imageInfo = tesseraState.imageInfo,
+            error = tesseraState.error ?: loadError
+        )
+    } else {
+        vs.sync(
+            scale = scale,
+            zoomLevel = zoomLevel,
+            cachedTileCount = tileCount,
+            isLoading = loadError == null,
+            imageInfo = null,
+            error = loadError
+        )
+    }
 }

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
@@ -180,19 +180,10 @@ internal fun TesseraImageContent(
                     currentZoomLevel = newZoomLevel
                 }
 
-                // Skip tile loading at zoom level 0 when the viewport covers the
-                // full image — the preview bitmap (1024px) is sufficient.
-                // FitWidth/FitHeight modes where the viewport only shows a portion
-                // of the image still load tiles for sharp scrollable content.
-                if (newZoomLevel == 0) {
-                    val vp = state.viewport
-                    val info = state.imageInfo
-                    if (info == null ||
-                        (vp.viewWidth >= info.width.toFloat() - 1f &&
-                         vp.viewHeight >= info.height.toFloat() - 1f)
-                    ) {
-                        return@collect
-                    }
+                if (newZoomLevel == 0 &&
+                    shouldSkipZeroLevelTiles(state.viewport, state.imageInfo)
+                ) {
+                    return@collect
                 }
 
                 val tilesToLoad = visibleTiles.filter { it.toKey() !in loadedTiles.keys }
@@ -838,6 +829,25 @@ internal fun resolveContentScale(
         imageAspect > viewAspect * 1.5f -> ContentScale.FitHeight // wide image
         else -> ContentScale.Fit
     }
+}
+
+/**
+ * At zoom level 0 the preview bitmap (~1024px) is already on screen. Loading tiles
+ * only pays off when the viewport shows a *partial* slice of the source image —
+ * i.e. FitWidth/FitHeight modes where the user will scroll to see more. If the
+ * viewport already covers the full image (or image info is missing), skip tiles.
+ *
+ * `viewport.viewWidth/viewHeight` are in source-image coordinates (see
+ * TesseraImageContent viewport construction): they represent the image area
+ * clipped to the viewport, so equaling `imageInfo.width/height` means full cover.
+ */
+internal fun shouldSkipZeroLevelTiles(
+    viewport: Viewport,
+    imageInfo: ImageInfo?
+): Boolean {
+    if (imageInfo == null) return true
+    return viewport.viewWidth >= imageInfo.width.toFloat() - 1f &&
+        viewport.viewHeight >= imageInfo.height.toFloat() - 1f
 }
 
 internal fun computeFitScale(

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
@@ -89,6 +89,7 @@ internal fun TesseraImageContent(
     val zoomThreshold = 1.01f
     var currentTime by remember { mutableLongStateOf(currentTimeMillis()) }
     var isDismissing by remember { mutableStateOf(false) }
+    var isGesturing by remember { mutableStateOf(false) }
     var lastInteractionTime by remember { mutableLongStateOf(0L) }
 
     var dismissOffsetY by remember { mutableFloatStateOf(0f) }
@@ -159,10 +160,14 @@ internal fun TesseraImageContent(
     LaunchedEffect(tesseraState) {
         val state = tesseraState ?: return@LaunchedEffect
 
-        snapshotFlow { state.viewport }
-            .collect {
+        // Observe both viewport and gesture state. When isGesturing changes
+        // from true to false, snapshotFlow re-emits triggering tile load
+        // for the final viewport position.
+        snapshotFlow { state.viewport to isGesturing }
+            .collect { (_, gesturing) ->
                 if (isDismissing) return@collect
                 if (state.isLoading || state.error != null) return@collect
+                if (gesturing) return@collect
 
                 delay(20)
 
@@ -219,6 +224,7 @@ internal fun TesseraImageContent(
                 val chunkSize = 2
                 sortedTiles.chunked(chunkSize).forEach { chunk ->
                     ensureActive()
+                    if (isGesturing) return@collect
 
                     val results = supervisorScope {
                         chunk.map { coordinate ->
@@ -339,6 +345,9 @@ internal fun TesseraImageContent(
                             rotationZ = rotation.degrees.toFloat()
                             clip = true
                         }
+                        // Desktop scroll handler: isGesturing not set here because scroll
+                        // events are discrete (not continuous like touch), so each event
+                        // naturally debounces via the 20ms delay in tile loading.
                         .pointerInput(contentScale, rotation) {
                             awaitPointerEventScope {
                                 while (true) {
@@ -436,6 +445,7 @@ internal fun TesseraImageContent(
                         .pointerInput(enablePagerIntegration, enableDismissGesture, contentScale, rotation) {
                             awaitEachGesture {
                                 val down = awaitFirstDown(requireUnconsumed = false)
+                                isGesturing = true
                                 var shouldConsume = !enablePagerIntegration
                                 var atEdge = false
                                 var totalPan = Offset.Zero
@@ -577,6 +587,7 @@ internal fun TesseraImageContent(
                                         }
                                     }
                                 } while (changes.fastAny { it.pressed })
+                                isGesturing = false
 
                                 // Double-tap detection: short gesture with no significant pan
                                 val gestureDuration = currentTimeMillis() - gestureStartTime

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
@@ -44,8 +44,11 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import kotlin.coroutines.cancellation.CancellationException
@@ -171,21 +174,19 @@ internal fun TesseraImageContent(
                     currentZoomLevel = newZoomLevel
                 }
 
-                // Skip tile loading when not zoomed in and the entire image fits
-                // in the viewport — preview bitmap is sufficient in this case.
-                // FitWidth/FitHeight modes may have scale=1.0 but only show a portion,
-                // so check that the viewport covers the full image dimensions.
-                // viewWidth/viewHeight are in image pixel coordinates (not screen pixels).
-                val vp = state.viewport
-                val info = state.imageInfo
-                if (vp.scale <= zoomThreshold && info != null &&
-                    vp.viewWidth >= info.width.toFloat() - 1f &&
-                    vp.viewHeight >= info.height.toFloat() - 1f
-                ) {
-                    logWarning("TesseraPerf", "skip tiles: preview sufficient " +
-                        "(viewport ${vp.viewWidth.toInt()}x${vp.viewHeight.toInt()} " +
-                        ">= image ${info.width}x${info.height}, scale=${vp.scale})")
-                    return@collect
+                // Skip tile loading at zoom level 0 when the viewport covers the
+                // full image — the preview bitmap (1024px) is sufficient.
+                // FitWidth/FitHeight modes where the viewport only shows a portion
+                // of the image still load tiles for sharp scrollable content.
+                if (newZoomLevel == 0) {
+                    val vp = state.viewport
+                    val info = state.imageInfo
+                    if (info == null ||
+                        (vp.viewWidth >= info.width.toFloat() - 1f &&
+                         vp.viewHeight >= info.height.toFloat() - 1f)
+                    ) {
+                        return@collect
+                    }
                 }
 
                 val tilesToLoad = visibleTiles.filter { it.toKey() !in loadedTiles.keys }
@@ -212,26 +213,37 @@ internal fun TesseraImageContent(
                 var loadedCount = 0
                 var failCount = 0
 
-                sortedTiles.forEach { coordinate ->
+                // Decode tiles in parallel chunks matching decoder pool size.
+                // Each chunk is decoded concurrently, then cached immediately
+                // so tiles appear progressively instead of all at once.
+                val chunkSize = 2
+                sortedTiles.chunked(chunkSize).forEach { chunk ->
                     ensureActive()
 
-                    val key = coordinate.toKey()
-                    try {
-                        val bitmap = withContext(ioDispatcher) {
-                            state.decodeTile(coordinate)
-                        }
+                    val results = supervisorScope {
+                        chunk.map { coordinate ->
+                            async(ioDispatcher) {
+                                try {
+                                    coordinate to state.decodeTile(coordinate)
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    logError("TesseraImage", "tile decode failed: ${coordinate.toKey()}", e)
+                                    coordinate to null
+                                }
+                            }
+                        }.awaitAll()
+                    }
 
+                    for ((coordinate, bitmap) in results) {
                         if (bitmap != null) {
                             state.cacheTile(coordinate, bitmap)
                             val loadTime = currentTimeMillis()
-                            loadedTiles = loadedTiles + (key to TileLoadInfo(loadTime, coordinate.zoomLevel))
+                            loadedTiles = loadedTiles + (coordinate.toKey() to TileLoadInfo(loadTime, coordinate.zoomLevel))
                             loadedCount++
+                        } else {
+                            failCount++
                         }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        logError("TesseraImage", "tile decode failed: $key", e)
-                        failCount++
                     }
                     yield()
                 }

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
@@ -75,6 +75,7 @@ internal fun TesseraImageContent(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    tileAnimationDurationMs: Int = 200,
     viewerState: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
@@ -710,30 +711,52 @@ internal fun TesseraImageContent(
                             )
                         }
 
+                        val animDuration = tileAnimationDurationMs.coerceAtLeast(0).toLong()
+
+                        // Compute crossfade reference once (not per tile)
+                        val oldestCurrentTile = loadedTiles.values
+                            .filter { it.zoomLevel == currentZoomLevel }
+                            .minByOrNull { it.loadTime }
+
+                        // Previous zoom level tiles: crossfade out as current tiles load
                         loadedTiles
                             .filter { it.value.zoomLevel < currentZoomLevel }
                             .forEach { (tileKey, _) ->
                                 state.getCachedTileByKey(tileKey)?.let { (bitmap, coordinate) ->
                                     val tileRect = state.getTileRect(coordinate)
-                                    drawTileWithRect(
-                                        bitmap = bitmap,
-                                        tileRect = tileRect,
-                                        totalScale = totalScale,
-                                        baseOffset = baseOffset,
-                                        alpha = 1f
-                                    )
+                                    val fadeOutAlpha = if (oldestCurrentTile == null) {
+                                        // No current tiles yet: keep previous tiles visible
+                                        1f
+                                    } else if (animDuration > 0) {
+                                        val elapsed = currentTime - oldestCurrentTile.loadTime
+                                        val t = (elapsed.toFloat() / animDuration).coerceIn(0f, 1f)
+                                        1f - easeOut(t)
+                                    } else {
+                                        // Animation disabled: hide previous tiles instantly
+                                        0f
+                                    }
+                                    if (fadeOutAlpha > 0.01f) {
+                                        drawTileWithRect(
+                                            bitmap = bitmap,
+                                            tileRect = tileRect,
+                                            totalScale = totalScale,
+                                            baseOffset = baseOffset,
+                                            alpha = fadeOutAlpha
+                                        )
+                                    }
                                 }
                             }
 
+                        // Current zoom level tiles: fade in with EaseOut
                         loadedTiles
                             .filter { it.value.zoomLevel == currentZoomLevel }
                             .forEach { (tileKey, info) ->
                                 state.getCachedTileByKey(tileKey)?.let { (bitmap, coordinate) ->
                                     val tileRect = state.getTileRect(coordinate)
-                                    val fadeInDuration = 100L
                                     val elapsedTime = currentTime - info.loadTime
-                                    val alpha = if (elapsedTime < fadeInDuration) {
-                                        (elapsedTime.toFloat() / fadeInDuration).coerceIn(0f, 1f)
+                                    val alpha = if (animDuration > 0 && elapsedTime < animDuration) {
+                                        val t = (elapsedTime.toFloat() / animDuration).coerceIn(0f, 1f)
+                                        easeOut(t)
                                     } else {
                                         1f
                                     }
@@ -985,6 +1008,9 @@ private fun DrawScope.drawMinimap(
         style = Stroke(width = borderWidth)
     )
 }
+
+/** EaseOut interpolation: fast start, slow finish. t in [0, 1]. */
+internal fun easeOut(t: Float): Float = 1f - (1f - t) * (1f - t)
 
 internal fun syncViewerState(
     vs: TesseraViewerState,

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraImageContent.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.semantics.contentDescription
@@ -74,6 +75,8 @@ internal fun TesseraImageContent(
     viewerState: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
+    val density = LocalDensity.current.density
+    val tileSize = remember(density) { (256 * density).roundToInt().coerceIn(256, 512) }
     var tesseraState by remember { mutableStateOf<TesseraState?>(null) }
     var loadError by remember { mutableStateOf<String?>(null) }
     var scale by remember { mutableFloatStateOf(1f) }
@@ -105,7 +108,7 @@ internal fun TesseraImageContent(
         }
     }
 
-    LaunchedEffect(imageUrl, imageLoader) {
+    LaunchedEffect(imageUrl, imageLoader, tileSize) {
         try {
             val previousState = tesseraState
             tesseraState = null
@@ -123,7 +126,7 @@ internal fun TesseraImageContent(
             }
             val source = result.getOrNull()
             if (source != null) {
-                val state = TesseraState(source, decoderFactory)
+                val state = TesseraState(source, decoderFactory, tileSize = tileSize)
                 val initResult = withContext(imageLoadDispatcher) {
                     state.initializeDecoder()
                 }

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraState.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraState.kt
@@ -2,6 +2,7 @@ package com.github.bentleypark.tessera
 
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -36,6 +37,11 @@ class TesseraState(
     var viewport by mutableStateOf(Viewport())
         private set
     var previewBitmap by mutableStateOf<ImageBitmap?>(null)
+        private set
+
+    /** Number of tiles currently held in the LRU cache. Tracked separately to avoid
+     *  subscribing composition to the entire SnapshotStateMap. */
+    var cachedTileCount by mutableIntStateOf(0)
         private set
 
     /** Synchronous init for testing and simple usage. Must be called on the main thread. */
@@ -185,6 +191,7 @@ class TesseraState(
         evictLRUIfNeeded()
         tileCache[key] = bitmap to coordinate
         updateAccessOrder(key)
+        cachedTileCount = tileCache.size
     }
 
     private fun evictLRUIfNeeded() {
@@ -204,5 +211,6 @@ class TesseraState(
         decoder = null
         tileCache.clear()
         tileCacheAccessOrder.clear()
+        cachedTileCount = 0
     }
 }

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraState.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraState.kt
@@ -17,7 +17,8 @@ import kotlin.coroutines.cancellation.CancellationException
 class TesseraState(
     private val imageSource: ImageSource,
     private val decoderFactory: (ImageSource) -> RegionDecoder,
-    private val maxCacheSize: Int = 150
+    private val tileSize: Int = 256,
+    private val maxCacheSize: Int = (150 * 256 * 256 / (tileSize * tileSize)).coerceAtLeast(50)
 ) {
     @Volatile
     private var decoder: RegionDecoder? = null
@@ -64,7 +65,7 @@ class TesseraState(
             val decoderTime = currentTimeMillis() - initStart
 
             decoder = regionDecoder
-            tileManager = TileManager(info)
+            tileManager = TileManager(info, tileSize)
 
             // Warn about large non-JPEG images (subsample APIs don't save memory for PNG, etc.)
             val format = ImageFormat.fromMimeType(info.mimeType)

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraViewerState.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TesseraViewerState.kt
@@ -1,0 +1,89 @@
+package com.github.bentleypark.tessera
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * Observable state for the Tessera image viewer.
+ *
+ * Use [rememberTesseraState] to create an instance and pass it to [TesseraImage]
+ * to observe zoom level, loading state, image metadata, and other viewer properties
+ * from outside the composable.
+ *
+ * ```kotlin
+ * val state = rememberTesseraState()
+ *
+ * TesseraImage(
+ *     imageUrl = "https://example.com/large-image.jpg",
+ *     state = state
+ * )
+ *
+ * // Observe state externally
+ * Text("Scale: ${state.scale}")
+ * Text("Loading: ${state.isLoading}")
+ * state.imageInfo?.let { Text("Size: ${it.width} x ${it.height}") }
+ * ```
+ */
+@Stable
+class TesseraViewerState {
+    /** Current user zoom scale (1.0 = no zoom). Does not include fitScale. */
+    var scale: Float by mutableFloatStateOf(1f)
+        internal set
+
+    /** True while the image is being downloaded and decoded for the first time. */
+    var isLoading: Boolean by mutableStateOf(true)
+        internal set
+
+    /** Image metadata (width, height, mimeType). Null until loading completes. */
+    var imageInfo: ImageInfo? by mutableStateOf(null)
+        internal set
+
+    /** Error message if image loading or decoding failed. Null on success. */
+    var error: String? by mutableStateOf(null)
+        internal set
+
+    /** Current tile zoom level (0–3). -1 before any tiles are loaded. */
+    var zoomLevel: Int by mutableIntStateOf(-1)
+        internal set
+
+    /** Number of tiles currently cached in memory. */
+    var cachedTileCount: Int by mutableIntStateOf(0)
+        internal set
+
+    /** True when the image has loaded successfully and tiles are being rendered. */
+    val isReady: Boolean
+        get() = !isLoading && error == null && imageInfo != null
+
+    internal fun sync(
+        scale: Float,
+        zoomLevel: Int,
+        cachedTileCount: Int,
+        isLoading: Boolean,
+        imageInfo: ImageInfo?,
+        error: String?
+    ) {
+        this.scale = scale
+        this.zoomLevel = zoomLevel
+        this.cachedTileCount = cachedTileCount
+        this.isLoading = isLoading
+        this.imageInfo = imageInfo
+        this.error = error
+    }
+}
+
+/**
+ * Creates and remembers a [TesseraViewerState] instance.
+ *
+ * Pass the returned state to [TesseraImage] via the `state` parameter,
+ * then observe its properties to react to viewer changes.
+ */
+@Composable
+fun rememberTesseraState(): TesseraViewerState {
+    return remember { TesseraViewerState() }
+}

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TileManager.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/TileManager.kt
@@ -45,14 +45,16 @@ class TileManager(
         )
     }
 
-    fun getVisibleTiles(viewport: Viewport): List<TileCoordinate> {
+    fun getVisibleTiles(viewport: Viewport, prefetchMargin: Int = tileSize / 2): List<TileCoordinate> {
         val zoomLevel = calculateZoomLevel(viewport.scale)
         val grid = createTileGrid(zoomLevel)
 
-        val viewportLeft = max(0f, viewport.offsetX)
-        val viewportTop = max(0f, viewport.offsetY)
-        val viewportRight = min(imageInfo.width.toFloat(), viewport.offsetX + viewport.viewWidth)
-        val viewportBottom = min(imageInfo.height.toFloat(), viewport.offsetY + viewport.viewHeight)
+        // Expand viewport by prefetch margin to pre-decode tiles about to scroll into view
+        val margin = prefetchMargin.toFloat()
+        val viewportLeft = max(0f, viewport.offsetX - margin)
+        val viewportTop = max(0f, viewport.offsetY - margin)
+        val viewportRight = min(imageInfo.width.toFloat(), viewport.offsetX + viewport.viewWidth + margin)
+        val viewportBottom = min(imageInfo.height.toFloat(), viewport.offsetY + viewport.viewHeight + margin)
 
         val startCol = max(0, floor(viewportLeft / tileSize).toInt())
         val startRow = max(0, floor(viewportTop / tileSize).toInt())

--- a/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/EaseOutTest.kt
+++ b/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/EaseOutTest.kt
@@ -1,0 +1,36 @@
+package com.github.bentleypark.tessera
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EaseOutTest {
+
+    @Test
+    fun easeOut_zero_returnsZero() {
+        assertEquals(0f, easeOut(0f))
+    }
+
+    @Test
+    fun easeOut_one_returnsOne() {
+        assertEquals(1f, easeOut(1f))
+    }
+
+    @Test
+    fun easeOut_midpoint_greaterThanLinear() {
+        // EaseOut at t=0.5 should be > 0.5 (fast start)
+        val result = easeOut(0.5f)
+        assertTrue(result > 0.5f, "easeOut(0.5) = $result should be > 0.5")
+    }
+
+    @Test
+    fun easeOut_monotonicallyIncreasing() {
+        var prev = 0f
+        for (i in 1..10) {
+            val t = i / 10f
+            val value = easeOut(t)
+            assertTrue(value >= prev, "easeOut($t) = $value should be >= easeOut(${(i-1)/10f}) = $prev")
+            prev = value
+        }
+    }
+}

--- a/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/TesseraViewerStateTest.kt
+++ b/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/TesseraViewerStateTest.kt
@@ -1,0 +1,194 @@
+package com.github.bentleypark.tessera
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TesseraViewerStateTest {
+
+    @Test
+    fun defaultValues() {
+        val state = TesseraViewerState()
+        assertEquals(1f, state.scale)
+        assertTrue(state.isLoading)
+        assertNull(state.imageInfo)
+        assertNull(state.error)
+        assertEquals(-1, state.zoomLevel)
+        assertEquals(0, state.cachedTileCount)
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun isReady_trueWhenLoadedSuccessfully() {
+        val state = TesseraViewerState()
+        state.isLoading = false
+        state.imageInfo = ImageInfo(width = 4000, height = 3000, mimeType = "image/jpeg")
+        state.error = null
+
+        assertTrue(state.isReady)
+    }
+
+    @Test
+    fun isReady_falseWhileLoading() {
+        val state = TesseraViewerState()
+        state.isLoading = true
+        state.imageInfo = ImageInfo(width = 4000, height = 3000)
+
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun isReady_falseOnError() {
+        val state = TesseraViewerState()
+        state.isLoading = false
+        state.error = "decode failed"
+        state.imageInfo = null
+
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun isReady_falseWhenErrorPresentEvenWithImageInfo() {
+        val state = TesseraViewerState()
+        state.isLoading = false
+        state.imageInfo = ImageInfo(width = 4000, height = 3000)
+        state.error = "partial failure"
+
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun isReady_falseWhenImageInfoIsNull() {
+        val state = TesseraViewerState()
+        state.isLoading = false
+        state.error = null
+
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun scaleUpdates() {
+        val state = TesseraViewerState()
+        state.scale = 3.5f
+        assertEquals(3.5f, state.scale)
+    }
+
+    @Test
+    fun zoomLevelUpdates() {
+        val state = TesseraViewerState()
+        state.zoomLevel = 2
+        assertEquals(2, state.zoomLevel)
+    }
+
+    @Test
+    fun cachedTileCountUpdates() {
+        val state = TesseraViewerState()
+        state.cachedTileCount = 42
+        assertEquals(42, state.cachedTileCount)
+    }
+
+    @Test
+    fun imageInfoUpdates() {
+        val state = TesseraViewerState()
+        val info = ImageInfo(width = 8000, height = 6000, mimeType = "image/png")
+        state.imageInfo = info
+        assertEquals(8000, state.imageInfo?.width)
+        assertEquals(6000, state.imageInfo?.height)
+        assertEquals("image/png", state.imageInfo?.mimeType)
+    }
+
+    @Test
+    fun stateCanTransitionBackToLoading() {
+        val state = TesseraViewerState()
+        state.isLoading = false
+        state.imageInfo = ImageInfo(width = 100, height = 100)
+        assertTrue(state.isReady)
+
+        state.isLoading = true
+        state.imageInfo = null
+        assertFalse(state.isReady)
+    }
+
+    @Test
+    fun syncUpdatesAllFieldsAtomically() {
+        val state = TesseraViewerState()
+        val info = ImageInfo(width = 2000, height = 1500, mimeType = "image/jpeg")
+
+        state.sync(
+            scale = 2.5f,
+            zoomLevel = 1,
+            cachedTileCount = 10,
+            isLoading = false,
+            imageInfo = info,
+            error = null
+        )
+
+        assertEquals(2.5f, state.scale)
+        assertEquals(1, state.zoomLevel)
+        assertEquals(10, state.cachedTileCount)
+        assertFalse(state.isLoading)
+        assertEquals(info, state.imageInfo)
+        assertNull(state.error)
+        assertTrue(state.isReady)
+    }
+
+    @Test
+    fun syncWithError() {
+        val state = TesseraViewerState()
+
+        state.sync(
+            scale = 1f,
+            zoomLevel = -1,
+            cachedTileCount = 0,
+            isLoading = false,
+            imageInfo = null,
+            error = "load failed"
+        )
+
+        assertFalse(state.isLoading)
+        assertNull(state.imageInfo)
+        assertEquals("load failed", state.error)
+        assertFalse(state.isReady)
+    }
+}
+
+class SyncViewerStateTest {
+
+    @Test
+    fun syncWithNullTesseraState_noError() {
+        val vs = TesseraViewerState()
+
+        syncViewerState(
+            vs = vs,
+            scale = 1f,
+            zoomLevel = -1,
+            tileCount = 0,
+            tesseraState = null,
+            loadError = null
+        )
+
+        assertTrue(vs.isLoading)
+        assertNull(vs.imageInfo)
+        assertNull(vs.error)
+    }
+
+    @Test
+    fun syncWithNullTesseraState_withLoadError() {
+        val vs = TesseraViewerState()
+
+        syncViewerState(
+            vs = vs,
+            scale = 1f,
+            zoomLevel = -1,
+            tileCount = 0,
+            tesseraState = null,
+            loadError = "network error"
+        )
+
+        assertFalse(vs.isLoading)
+        assertNull(vs.imageInfo)
+        assertEquals("network error", vs.error)
+    }
+}

--- a/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/TileManagerTest.kt
+++ b/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/TileManagerTest.kt
@@ -255,4 +255,60 @@ class TileManagerTest {
         assertEquals(4, grid.columns)
         assertEquals(3, grid.rows)
     }
+
+    // --- Large image tile count reduction with bigger tile size ---
+
+    @Test
+    fun largerTileSize_reducesTileCount_108MP() {
+        val largeImage = ImageInfo(width = 12000, height = 7149)
+        val small = TileManager(largeImage, tileSize = 256)
+        val large = TileManager(largeImage, tileSize = 512)
+
+        val gridSmall = small.createTileGrid(0) // sampleSize=2 → 6000x3575
+        val gridLarge = large.createTileGrid(0) // sampleSize=2 → 6000x3575
+
+        // 256px: ceil(6000/256)=24, ceil(3575/256)=14 → 336
+        assertEquals(24, gridSmall.columns)
+        assertEquals(14, gridSmall.rows)
+        assertEquals(336, gridSmall.totalTiles)
+
+        // 512px: ceil(6000/512)=12, ceil(3575/512)=7 → 84
+        assertEquals(12, gridLarge.columns)
+        assertEquals(7, gridLarge.rows)
+        assertEquals(84, gridLarge.totalTiles)
+
+        // 75% reduction
+        assertTrue(gridLarge.totalTiles < gridSmall.totalTiles / 3)
+    }
+
+    @Test
+    fun largerTileSize_fewerVisibleTiles() {
+        val largeImage = ImageInfo(width = 4000, height = 3000)
+        val small = TileManager(largeImage, tileSize = 256)
+        val large = TileManager(largeImage, tileSize = 512)
+
+        // Zoomed-in viewport covering ~1000x1000 image pixels
+        val viewport = Viewport(
+            offsetX = 1000f,
+            offsetY = 1000f,
+            scale = 2.0f,
+            viewWidth = 1000f,
+            viewHeight = 1000f
+        )
+
+        val tilesSmall = small.getVisibleTiles(viewport)
+        val tilesLarge = large.getVisibleTiles(viewport)
+
+        assertTrue(tilesLarge.size < tilesSmall.size,
+            "512px tiles (${tilesLarge.size}) should be fewer than 256px tiles (${tilesSmall.size})")
+    }
+
+    @Test
+    fun tileSize_384_intermediateValue() {
+        val mgr = TileManager(imageInfo, tileSize = 384)
+        val grid = mgr.createTileGrid(1)
+        // columns = ceil(1920/384) = 5, rows = ceil(1080/384) = 3
+        assertEquals(5, grid.columns)
+        assertEquals(3, grid.rows)
+    }
 }

--- a/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/TileManagerTest.kt
+++ b/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/TileManagerTest.kt
@@ -144,9 +144,9 @@ class TileManagerTest {
             viewWidth = 256f,
             viewHeight = 256f
         )
-        val tiles = manager.getVisibleTiles(viewport)
+        val tiles = manager.getVisibleTiles(viewport, prefetchMargin = 0)
         assertTrue(tiles.isNotEmpty())
-        // All tiles should be in the offset region
+        // All tiles should be in the offset region (no prefetch margin)
         tiles.forEach { tile ->
             assertTrue(tile.col >= 2, "col ${tile.col} should be >= 2")
             assertTrue(tile.row >= 2, "row ${tile.row} should be >= 2")
@@ -301,6 +301,61 @@ class TileManagerTest {
 
         assertTrue(tilesLarge.size < tilesSmall.size,
             "512px tiles (${tilesLarge.size}) should be fewer than 256px tiles (${tilesSmall.size})")
+    }
+
+    // --- Prefetch margin ---
+
+    @Test
+    fun prefetchMargin_expandsVisibleTiles() {
+        val viewport = Viewport(
+            offsetX = 512f,
+            offsetY = 512f,
+            scale = 2.0f,
+            viewWidth = 500f,
+            viewHeight = 500f
+        )
+        val withoutMargin = manager.getVisibleTiles(viewport, prefetchMargin = 0)
+        val withMargin = manager.getVisibleTiles(viewport, prefetchMargin = 128)
+
+        assertTrue(withMargin.size > withoutMargin.size,
+            "Prefetch margin should include more tiles: ${withMargin.size} > ${withoutMargin.size}")
+        // All non-margin tiles should be included in margin result
+        withoutMargin.forEach { tile ->
+            assertTrue(tile in withMargin, "Visible tile $tile should be in prefetched set")
+        }
+    }
+
+    @Test
+    fun prefetchMargin_zero_matchesExactViewport() {
+        val viewport = Viewport(
+            offsetX = 256f,
+            offsetY = 256f,
+            scale = 2.0f,
+            viewWidth = 256f,
+            viewHeight = 256f
+        )
+        val noMargin = manager.getVisibleTiles(viewport, prefetchMargin = 0)
+        val defaultMargin = manager.getVisibleTiles(viewport)
+
+        assertTrue(defaultMargin.size >= noMargin.size,
+            "Default margin should include at least as many tiles")
+    }
+
+    @Test
+    fun prefetchMargin_clampedToImageBounds() {
+        // Viewport at top-left corner — margin can't go below 0
+        val viewport = Viewport(
+            offsetX = 0f,
+            offsetY = 0f,
+            scale = 2.0f,
+            viewWidth = 300f,
+            viewHeight = 300f
+        )
+        val tiles = manager.getVisibleTiles(viewport, prefetchMargin = 500)
+        tiles.forEach { tile ->
+            assertTrue(tile.col >= 0, "col should be >= 0")
+            assertTrue(tile.row >= 0, "row should be >= 0")
+        }
     }
 
     @Test

--- a/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/ZeroLevelTileSkipTest.kt
+++ b/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/ZeroLevelTileSkipTest.kt
@@ -1,0 +1,101 @@
+package com.github.bentleypark.tessera
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the zoom-level-0 tile-skip decision used by TesseraImageContent.
+ *
+ * The rule: at level 0 tiles are redundant only when the viewport covers the
+ * entire source image. FitWidth/FitHeight modes (partial viewport) must still
+ * load tiles, or scrolled content falls back to the blurry preview bitmap.
+ */
+class ZeroLevelTileSkipTest {
+
+    // --- Full cover (Fit mode) — should skip ---
+
+    @Test
+    fun fit_viewportCoversEntireImage_skips() {
+        // Classic Fit: fitScale chosen so that viewport == image on both axes.
+        val viewport = Viewport(viewWidth = 800f, viewHeight = 600f)
+        val info = ImageInfo(width = 800, height = 600)
+        assertTrue(shouldSkipZeroLevelTiles(viewport, info))
+    }
+
+    @Test
+    fun fit_viewportMarginallyLarger_skips() {
+        // Guards the `-1f` tolerance: floating-point drift by <1px still skips.
+        val viewport = Viewport(viewWidth = 800.4f, viewHeight = 600.2f)
+        val info = ImageInfo(width = 800, height = 600)
+        assertTrue(shouldSkipZeroLevelTiles(viewport, info))
+    }
+
+    // --- FitWidth (tall image, vertical scroll) — should NOT skip ---
+
+    @Test
+    fun fitWidth_tallImageOverflowsVertically_loadsTiles() {
+        // Webtoon: image 600x3000, fit to 400-wide viewport →
+        // viewport in image coords = 600 x (800/fitScale) where fitScale=400/600.
+        // viewportHeight ≈ 1200 < imageHeight 3000 → must load tiles.
+        val viewport = Viewport(viewWidth = 600f, viewHeight = 1200f)
+        val info = ImageInfo(width = 600, height = 3000)
+        assertFalse(shouldSkipZeroLevelTiles(viewport, info))
+    }
+
+    // --- FitHeight (wide panorama, horizontal scroll) — should NOT skip ---
+
+    @Test
+    fun fitHeight_wideImageOverflowsHorizontally_loadsTiles() {
+        // Panorama: image 3000x600, fit to 800-tall viewport →
+        // viewportWidth < imageWidth → tiles required.
+        val viewport = Viewport(viewWidth = 2000f, viewHeight = 600f)
+        val info = ImageInfo(width = 3000, height = 600)
+        assertFalse(shouldSkipZeroLevelTiles(viewport, info))
+    }
+
+    // --- Partial coverage on a single axis is enough to require tiles ---
+
+    @Test
+    fun partialHorizontalCoverage_loadsTiles() {
+        val viewport = Viewport(viewWidth = 799f, viewHeight = 600f)
+        val info = ImageInfo(width = 1200, height = 600)
+        assertFalse(shouldSkipZeroLevelTiles(viewport, info))
+    }
+
+    @Test
+    fun partialVerticalCoverage_loadsTiles() {
+        val viewport = Viewport(viewWidth = 800f, viewHeight = 599f)
+        val info = ImageInfo(width = 800, height = 1200)
+        assertFalse(shouldSkipZeroLevelTiles(viewport, info))
+    }
+
+    // --- Null image info — skip defensively (nothing to decode) ---
+
+    @Test
+    fun nullImageInfo_skips() {
+        assertTrue(shouldSkipZeroLevelTiles(Viewport(), imageInfo = null))
+    }
+
+    // --- Default viewport (before layout) with valid info — does not skip ---
+
+    @Test
+    fun zeroViewport_doesNotSkip() {
+        // Before the first layout pass viewport is (0,0). We prefer "no skip"
+        // so the next viewport update re-triggers evaluation instead of
+        // latching the skip branch.
+        val viewport = Viewport()
+        val info = ImageInfo(width = 800, height = 600)
+        assertFalse(shouldSkipZeroLevelTiles(viewport, info))
+    }
+
+    // --- Sanity: exact boundary within tolerance ---
+
+    @Test
+    fun exactBoundary_skips() {
+        val viewport = Viewport(viewWidth = 1024f, viewHeight = 768f)
+        val info = ImageInfo(width = 1024, height = 768)
+        assertEquals(true, shouldSkipZeroLevelTiles(viewport, info))
+    }
+}

--- a/tessera-core/src/desktopMain/kotlin/com/github/bentleypark/tessera/TesseraImage.desktop.kt
+++ b/tessera-core/src/desktopMain/kotlin/com/github/bentleypark/tessera/TesseraImage.desktop.kt
@@ -33,6 +33,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    tileAnimationDurationMs: Int = 200,
     state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
@@ -53,6 +54,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        tileAnimationDurationMs = tileAnimationDurationMs,
         viewerState = state,
         onDismiss = onDismiss
     )

--- a/tessera-core/src/desktopMain/kotlin/com/github/bentleypark/tessera/TesseraImage.desktop.kt
+++ b/tessera-core/src/desktopMain/kotlin/com/github/bentleypark/tessera/TesseraImage.desktop.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
  * @param enableDismissGesture Enable vertical drag-to-dismiss gesture
  * @param enablePagerIntegration Enable horizontal swipe pass-through to parent pager
  * @param showScrollIndicators Show scroll position indicators when zoomed
+ * @param state Observable viewer state created via [rememberTesseraState]
  * @param onDismiss Callback invoked when dismiss gesture is completed
  */
 @Composable
@@ -32,6 +33,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     val resolvedLoader = remember(imageLoader) { imageLoader ?: DesktopImageLoader() }
@@ -51,6 +53,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        viewerState = state,
         onDismiss = onDismiss
     )
 }

--- a/tessera-core/src/iosMain/kotlin/com/github/bentleypark/tessera/MainViewController.kt
+++ b/tessera-core/src/iosMain/kotlin/com/github/bentleypark/tessera/MainViewController.kt
@@ -116,6 +116,7 @@ private fun PagerGallery(
 ) {
     val pagerState = rememberPagerState(initialPage = initialPage) { images.size }
     var currentRotation by remember { mutableStateOf(ImageRotation.None) }
+    val viewerState = rememberTesseraState()
 
     Box(modifier = Modifier.fillMaxSize()) {
         HorizontalPager(
@@ -132,10 +133,20 @@ private fun PagerGallery(
                 enablePagerIntegration = isFitMode,
                 showScrollIndicators = true,
                 rotation = currentRotation,
+                state = if (page == pagerState.currentPage) viewerState else null,
                 onDismiss = onBack,
                 contentDescription = images[page].description
             )
         }
+
+        // State info overlay
+        StateInfoOverlay(
+            viewerState = viewerState,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 8.dp, bottom = 16.dp)
+                .zIndex(2f)
+        )
 
         // Page indicator
         Text(
@@ -252,5 +263,52 @@ private fun ImageSelectionScreen(scrollState: ScrollState, onSelect: (Int) -> Un
             color = Color.Gray,
             fontSize = 12.sp
         )
+    }
+}
+
+@Composable
+private fun StateInfoOverlay(
+    viewerState: TesseraViewerState,
+    modifier: Modifier = Modifier
+) {
+    val info = viewerState.imageInfo
+    val statusText = when {
+        viewerState.isLoading -> "Loading..."
+        viewerState.error != null -> "Error"
+        viewerState.isReady -> "Ready"
+        else -> "-"
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.Black.copy(alpha = 0.6f))
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Column {
+            Text(
+                text = statusText,
+                color = if (viewerState.isReady) Color.Green else Color.Yellow,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold
+            )
+            if (info != null) {
+                Text(
+                    text = "${info.width}x${info.height}",
+                    color = Color.White.copy(alpha = 0.8f),
+                    fontSize = 10.sp
+                )
+            }
+            Text(
+                text = "Zoom: ${((viewerState.scale * 10).toInt() / 10f)}x  Level: ${viewerState.zoomLevel}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
+            Text(
+                text = "Tiles: ${viewerState.cachedTileCount}",
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 10.sp
+            )
+        }
     }
 }

--- a/tessera-core/src/iosMain/kotlin/com/github/bentleypark/tessera/TesseraImage.ios.kt
+++ b/tessera-core/src/iosMain/kotlin/com/github/bentleypark/tessera/TesseraImage.ios.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
  * @param imageLoader Image loading strategy (default: IosImageLoader)
  * @param contentDescription Accessibility description
  * @param enableDismissGesture Enable vertical drag-to-dismiss gesture
+ * @param state Observable viewer state created via [rememberTesseraState]
  * @param onDismiss Callback invoked when dismiss gesture is completed
  */
 @Composable
@@ -30,6 +31,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     val resolvedLoader = remember(imageLoader) { imageLoader ?: IosImageLoader() }
@@ -49,6 +51,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        viewerState = state,
         onDismiss = onDismiss
     )
 }

--- a/tessera-core/src/iosMain/kotlin/com/github/bentleypark/tessera/TesseraImage.ios.kt
+++ b/tessera-core/src/iosMain/kotlin/com/github/bentleypark/tessera/TesseraImage.ios.kt
@@ -31,6 +31,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    tileAnimationDurationMs: Int = 200,
     state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
@@ -51,6 +52,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        tileAnimationDurationMs = tileAnimationDurationMs,
         viewerState = state,
         onDismiss = onDismiss
     )

--- a/tessera-core/src/wasmJsMain/kotlin/com/github/bentleypark/tessera/TesseraImage.wasmJs.kt
+++ b/tessera-core/src/wasmJsMain/kotlin/com/github/bentleypark/tessera/TesseraImage.wasmJs.kt
@@ -33,6 +33,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    tileAnimationDurationMs: Int = 200,
     state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
@@ -53,6 +54,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        tileAnimationDurationMs = tileAnimationDurationMs,
         viewerState = state,
         onDismiss = onDismiss
     )

--- a/tessera-core/src/wasmJsMain/kotlin/com/github/bentleypark/tessera/TesseraImage.wasmJs.kt
+++ b/tessera-core/src/wasmJsMain/kotlin/com/github/bentleypark/tessera/TesseraImage.wasmJs.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
  * @param enableDismissGesture Enable vertical drag-to-dismiss gesture
  * @param enablePagerIntegration Enable horizontal swipe pass-through to parent pager
  * @param showScrollIndicators Show scroll position indicators when zoomed
+ * @param state Observable viewer state created via [rememberTesseraState]
  * @param onDismiss Callback invoked when dismiss gesture is completed
  */
 @Composable
@@ -32,6 +33,7 @@ fun TesseraImage(
     enablePagerIntegration: Boolean = false,
     showScrollIndicators: Boolean = false,
     rotation: ImageRotation = ImageRotation.None,
+    state: TesseraViewerState? = null,
     onDismiss: () -> Unit = {}
 ) {
     val resolvedLoader = remember(imageLoader) { imageLoader ?: WasmImageLoader() }
@@ -51,6 +53,7 @@ fun TesseraImage(
         enablePagerIntegration = enablePagerIntegration,
         showScrollIndicators = showScrollIndicators,
         rotation = rotation,
+        viewerState = state,
         onDismiss = onDismiss
     )
 }


### PR DESCRIPTION
## Summary

- Dynamic tile size based on display density: `(256 * density).coerceIn(256, 512)` — up to 75% fewer tiles
- RGB_565 for JPEG tile decoding — 50% memory per tile (ARGB_8888 for PNG/alpha formats)
- BitmapRegionDecoder pool (2 instances) with safe lifecycle (`poll` timeout, `isClosed` flag)
- Chunked parallel tile decoding via `supervisorScope` + `async`
- Zoom level 0 tile skip when viewport covers full image (preview sufficient)
- `maxCacheSize` auto-scales inversely with tile size
- 8 new tests, README/CLAUDE.md updated

## Performance (108MP JPEG, 12000×7149)

| Scenario | Before | After |
|----------|--------|-------|
| Initial load (no zoom) | 336 tiles / ~252s | **0 tiles** (preview only) |
| Zoom level 0 (1.0-1.5x, Fit mode) | 84 tiles / ~63s | **0 tiles** (skipped) |
| Tile count at zoom 1+ | 256px grid | **512px grid** (75% fewer) |
| Memory per JPEG tile | 256KB (ARGB_8888) | **128KB (RGB_565)** |
| Decode throughput | 1 decoder | **2 decoders parallel** |

## Test plan

- [x] Desktop tests pass (`desktopTest`)
- [x] Android unit tests pass (`testDebugUnitTest` — 34 tests, 8 new)
- [x] Android sample build + runtime verified
- [x] Decoder pool log confirmed (`decoder pool: 2 instances`)
- [x] Zoom level 0 skip confirmed (no `zoom=0` tile logs in Fit mode)
- [x] FitWidth mode: tiles load at scale=1.0 (partial viewport) — covered by `ZeroLevelTileSkipTest` (9 cases incl. FitWidth/FitHeight)
- [x] Force-close and reopen: consistent behavior

Closes #42, closes #43, closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)