### PR TITLE
Fix tile/preview seam for non-square images with EXIF orientation 90/270 (#54)

### DIFF
--- a/tessera-core/src/androidUnitTest/kotlin/com/github/bentleypark/tessera/TesseraGestureTest.kt
+++ b/tessera-core/src/androidUnitTest/kotlin/com/github/bentleypark/tessera/TesseraGestureTest.kt
@@ -83,8 +83,13 @@ class TesseraGestureTest {
                 onDismiss = onDismiss
             )
         }
-        // Wait for image loading to complete
+        // Wait for image loading to complete. waitForIdle() only settles Compose
+        // recomposition, not the async decode on ioDispatcher (Dispatchers.IO), so
+        // poll the observable state until the load actually finishes.
         composeTestRule.waitForIdle()
+        if (viewerState != null) {
+            composeTestRule.waitUntil(timeoutMillis = 10_000) { viewerState.isReady }
+        }
     }
 
     // --- Rendering tests ---
@@ -366,7 +371,6 @@ class TesseraGestureTest {
     fun pinchZoom_pausesTileLoading_thenResumesAfterGesture() {
         val state = TesseraViewerState()
         setUpContent(viewerState = state, imageWidth = 4000, imageHeight = 3000)
-        composeTestRule.waitForIdle()
 
         // Record tile count before pinch
         val tilesBefore = state.cachedTileCount
@@ -395,7 +399,6 @@ class TesseraGestureTest {
     fun viewerState_reflectsStateAfterGesture() {
         val state = TesseraViewerState()
         setUpContent(viewerState = state)
-        composeTestRule.waitForIdle()
 
         assertTrue(state.isReady, "State should be ready after load")
 
@@ -447,7 +450,6 @@ class TesseraGestureTest {
     fun tileAnimation_zoomLevelTransition_noCrash() {
         val state = TesseraViewerState()
         setUpContent(tileAnimationDurationMs = 200, viewerState = state)
-        composeTestRule.waitForIdle()
 
         val node = composeTestRule.onNodeWithContentDescription(testContentDescription)
         // Zoom in (triggers zoom level change → crossfade)

--- a/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/ExifUtils.kt
+++ b/tessera-core/src/commonMain/kotlin/com/github/bentleypark/tessera/ExifUtils.kt
@@ -20,9 +20,9 @@ internal fun remapRectForOrientation(
     val rotated = when (rotationDegrees) {
         90 -> TileRect(
             left = rect.top,
-            top = rawWidth - rect.right,
+            top = rawHeight - rect.right,
             right = rect.bottom,
-            bottom = rawWidth - rect.left
+            bottom = rawHeight - rect.left
         )
         180 -> TileRect(
             left = rawWidth - rect.right,
@@ -31,9 +31,9 @@ internal fun remapRectForOrientation(
             bottom = rawHeight - rect.top
         )
         270 -> TileRect(
-            left = rawHeight - rect.bottom,
+            left = rawWidth - rect.bottom,
             top = rect.left,
-            right = rawHeight - rect.top,
+            right = rawWidth - rect.top,
             bottom = rect.right
         )
         else -> rect
@@ -41,7 +41,7 @@ internal fun remapRectForOrientation(
 
     if (!isMirrored) return rotated
 
-    // Mirror horizontally in raw coordinate space
-    val w = if (rotationDegrees == 90 || rotationDegrees == 270) rawHeight else rawWidth
-    return TileRect(w - rotated.right, rotated.top, w - rotated.left, rotated.bottom)
+    // Mirror horizontally in raw coordinate space. The remapped rect already lives
+    // in raw pixel space, whose X axis always spans rawWidth regardless of rotation.
+    return TileRect(rawWidth - rotated.right, rotated.top, rawWidth - rotated.left, rotated.bottom)
 }

--- a/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/ExifUtilsTest.kt
+++ b/tessera-core/src/commonTest/kotlin/com/github/bentleypark/tessera/ExifUtilsTest.kt
@@ -2,12 +2,20 @@ package com.github.bentleypark.tessera
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ExifUtilsTest {
 
     // Raw image: 1800x1200 (landscape)
     private val rawWidth = 1800
     private val rawHeight = 1200
+
+    /** Every remapped rect must be well-formed and stay within the raw image bounds. */
+    private fun assertWithinRawBounds(r: TileRect, w: Int = rawWidth, h: Int = rawHeight) {
+        assertTrue(r.left in 0..w && r.right in 0..w, "x out of raw bounds: $r (w=$w)")
+        assertTrue(r.top in 0..h && r.bottom in 0..h, "y out of raw bounds: $r (h=$h)")
+        assertTrue(r.left <= r.right && r.top <= r.bottom, "inverted rect: $r")
+    }
 
     // --- Orientation 0 (normal) ---
 
@@ -19,20 +27,22 @@ class ExifUtilsTest {
     }
 
     // --- Orientation 90° CW ---
-    // Display: 1200x1800 (portrait). Display (l,t,r,b) -> Raw (t, W-r, b, W-l)
+    // Display: 1200x1800 (portrait). Display (l,t,r,b) -> Raw (t, H-r, b, H-l)
 
     @Test
     fun remapRect_orientation90_topLeftTile() {
         val rect = TileRect(left = 0, top = 0, right = 256, bottom = 256)
         val result = remapRectForOrientation(rect, rawWidth, rawHeight, 90)
-        assertEquals(TileRect(left = 0, top = 1544, right = 256, bottom = 1800), result)
+        assertEquals(TileRect(left = 0, top = 944, right = 256, bottom = 1200), result)
+        assertWithinRawBounds(result)
     }
 
     @Test
     fun remapRect_orientation90_centerTile() {
         val rect = TileRect(left = 400, top = 600, right = 656, bottom = 856)
         val result = remapRectForOrientation(rect, rawWidth, rawHeight, 90)
-        assertEquals(TileRect(left = 600, top = 1144, right = 856, bottom = 1400), result)
+        assertEquals(TileRect(left = 600, top = 544, right = 856, bottom = 800), result)
+        assertWithinRawBounds(result)
     }
 
     @Test
@@ -40,8 +50,9 @@ class ExifUtilsTest {
         // Display is 1200x1800 (portrait after 90° rotation)
         val rect = TileRect(left = 0, top = 0, right = 1200, bottom = 1800)
         val result = remapRectForOrientation(rect, rawWidth, rawHeight, 90)
-        // Raw: (t=0, W-r=1800-1200=600, b=1800, W-l=1800-0=1800)
-        assertEquals(TileRect(left = 0, top = 600, right = 1800, bottom = 1800), result)
+        // Full display maps to the full raw image: (t=0, H-r=0, b=1800, H-l=1200)
+        assertEquals(TileRect(left = 0, top = 0, right = 1800, bottom = 1200), result)
+        assertWithinRawBounds(result)
     }
 
     // --- Orientation 180° ---
@@ -52,6 +63,7 @@ class ExifUtilsTest {
         val rect = TileRect(left = 0, top = 0, right = 256, bottom = 256)
         val result = remapRectForOrientation(rect, rawWidth, rawHeight, 180)
         assertEquals(TileRect(left = 1544, top = 944, right = 1800, bottom = 1200), result)
+        assertWithinRawBounds(result)
     }
 
     @Test
@@ -59,23 +71,34 @@ class ExifUtilsTest {
         val rect = TileRect(left = 0, top = 0, right = 1800, bottom = 1200)
         val result = remapRectForOrientation(rect, rawWidth, rawHeight, 180)
         assertEquals(TileRect(left = 0, top = 0, right = 1800, bottom = 1200), result)
+        assertWithinRawBounds(result)
     }
 
     // --- Orientation 270° CW ---
-    // Display: 1200x1800 (portrait). Display (l,t,r,b) -> Raw (H-b, l, H-t, r)
+    // Display: 1200x1800 (portrait). Display (l,t,r,b) -> Raw (W-b, l, W-t, r)
 
     @Test
     fun remapRect_orientation270_topLeftTile() {
         val rect = TileRect(left = 0, top = 0, right = 256, bottom = 256)
         val result = remapRectForOrientation(rect, rawWidth, rawHeight, 270)
-        assertEquals(TileRect(left = 944, top = 0, right = 1200, bottom = 256), result)
+        assertEquals(TileRect(left = 1544, top = 0, right = 1800, bottom = 256), result)
+        assertWithinRawBounds(result)
     }
 
     @Test
     fun remapRect_orientation270_centerTile() {
         val rect = TileRect(left = 400, top = 600, right = 656, bottom = 856)
         val result = remapRectForOrientation(rect, rawWidth, rawHeight, 270)
-        assertEquals(TileRect(left = 344, top = 400, right = 600, bottom = 656), result)
+        assertEquals(TileRect(left = 944, top = 400, right = 1200, bottom = 656), result)
+        assertWithinRawBounds(result)
+    }
+
+    @Test
+    fun remapRect_orientation270_fullImage() {
+        val rect = TileRect(left = 0, top = 0, right = 1200, bottom = 1800)
+        val result = remapRectForOrientation(rect, rawWidth, rawHeight, 270)
+        assertEquals(TileRect(left = 0, top = 0, right = 1800, bottom = 1200), result)
+        assertWithinRawBounds(result)
     }
 
     // --- Symmetry: remap + inverse remap = identity ---
@@ -84,8 +107,7 @@ class ExifUtilsTest {
     fun remapRect_90then270_returnsOriginal() {
         val original = TileRect(left = 100, top = 200, right = 356, bottom = 456)
         val remapped90 = remapRectForOrientation(original, rawWidth, rawHeight, 90)
-        // After 90° remap, dimensions swap: raw for 90° output uses rawWidth
-        // Inverse of 90° is 270° with swapped raw dimensions
+        // The inverse of a 90° remap is a 270° remap with swapped raw dimensions.
         val restored = remapRectForOrientation(remapped90, rawHeight, rawWidth, 270)
         assertEquals(original, restored)
     }
@@ -105,18 +127,35 @@ class ExifUtilsTest {
         val rect = TileRect(left = 100, top = 200, right = 356, bottom = 456)
         val result = remapRectForOrientation(rect, rawWidth, rawHeight, 0, isMirrored = true)
         assertEquals(TileRect(left = 1444, top = 200, right = 1700, bottom = 456), result)
+        assertWithinRawBounds(result)
+    }
+
+    @Test
+    fun remapRect_180withMirror_orientation4() {
+        // Orientation 4 = vertical flip. Independently: x unchanged, y flipped about rawHeight.
+        val rect = TileRect(left = 100, top = 200, right = 356, bottom = 456)
+        val result = remapRectForOrientation(rect, rawWidth, rawHeight, 180, isMirrored = true)
+        assertEquals(TileRect(left = 100, top = 744, right = 356, bottom = 1000), result)
+        assertWithinRawBounds(result)
     }
 
     @Test
     fun remapRect_90withMirror_orientation5() {
+        // Orientation 5 (transpose). Absolute literal so a regression in the mirror
+        // axis (must span rawWidth, not rawHeight) fails instead of silently passing.
         val rect = TileRect(left = 0, top = 0, right = 256, bottom = 256)
-        val rotated = remapRectForOrientation(rect, rawWidth, rawHeight, 90, isMirrored = false)
-        val mirrored = remapRectForOrientation(rect, rawWidth, rawHeight, 90, isMirrored = true)
-        // Mirror flips horizontally in raw space (rawHeight dimension for 90°)
-        assertEquals(rawHeight - rotated.right, mirrored.left)
-        assertEquals(rawHeight - rotated.left, mirrored.right)
-        assertEquals(rotated.top, mirrored.top)
-        assertEquals(rotated.bottom, mirrored.bottom)
+        val result = remapRectForOrientation(rect, rawWidth, rawHeight, 90, isMirrored = true)
+        assertEquals(TileRect(left = 1544, top = 944, right = 1800, bottom = 1200), result)
+        assertWithinRawBounds(result)
+    }
+
+    @Test
+    fun remapRect_270withMirror_orientation7() {
+        // Orientation 7 (transverse). Absolute literal, same rationale as orientation 5.
+        val rect = TileRect(left = 0, top = 0, right = 256, bottom = 256)
+        val result = remapRectForOrientation(rect, rawWidth, rawHeight, 270, isMirrored = true)
+        assertEquals(TileRect(left = 0, top = 0, right = 256, bottom = 256), result)
+        assertWithinRawBounds(result)
     }
 
     @Test
@@ -127,13 +166,38 @@ class ExifUtilsTest {
         assertEquals(original, restored)
     }
 
+    // --- Square image (rawWidth == rawHeight) ---
+    // The rawWidth/rawHeight swap is invisible here (|W-H| == 0), so these cases
+    // guard the formula in the region where the old buggy code also passed.
+
+    @Test
+    fun remapRect_squareImage_orientation90_inBounds() {
+        val size = 1000
+        val rect = TileRect(left = 0, top = 0, right = 256, bottom = 256)
+        val result = remapRectForOrientation(rect, size, size, 90)
+        assertEquals(TileRect(left = 0, top = 744, right = 256, bottom = 1000), result)
+        assertWithinRawBounds(result, size, size)
+    }
+
+    @Test
+    fun remapRect_squareImage_90then270_sameDimsReturnsOriginal() {
+        // For a square image the display dimensions do not swap, so the inverse of
+        // a 90° remap is a 270° remap with the SAME dimensions.
+        val size = 1000
+        val original = TileRect(left = 100, top = 200, right = 356, bottom = 456)
+        val remapped90 = remapRectForOrientation(original, size, size, 90)
+        val restored = remapRectForOrientation(remapped90, size, size, 270)
+        assertEquals(original, restored)
+    }
+
     // --- Edge cases ---
 
     @Test
     fun remapRect_zeroSizeRect_orientation90() {
         val rect = TileRect(left = 500, top = 500, right = 500, bottom = 500)
         val result = remapRectForOrientation(rect, rawWidth, rawHeight, 90)
-        assertEquals(TileRect(left = 500, top = 1300, right = 500, bottom = 1300), result)
+        assertEquals(TileRect(left = 500, top = 700, right = 500, bottom = 700), result)
+        assertWithinRawBounds(result)
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes a tile/preview misalignment (visible torn vertical seam) when zooming into **non-square images that carry EXIF orientation 6 (90° CW) or 8 (270° CW)** — e.g. a portrait phone photo stored as 4032×3024 landscape + orientation 6.

`remapRectForOrientation()` swapped `rawWidth`/`rawHeight` in the 90°/270° branches, so the tile path (`remapRect → decodeRegion`) decoded each tile from a source region shifted by `|rawWidth - rawHeight|` (1008px for a 4032×3024 photo), or one that fell outside the raw image bounds. The preview path rotates the whole bitmap correctly, so the two layers diverged once tiles became active on zoom.

Because `ExifUtils.kt` lives in `commonMain`, this one fix corrects **Android, iOS, and Desktop** decoders together.

## Root cause
| branch | before | after |
|---|---|---|
| 90° | `top/bottom = rawWidth - …` | `top/bottom = rawHeight - …` |
| 270° | `left/right = rawHeight - …` | `left/right = rawWidth - …` |
| mirror | `w = if (90/270) rawHeight else rawWidth` | `w = rawWidth` (raw X axis always spans rawWidth) |

The error is invisible for square images (`|W-H| == 0`) and for unrotated images, which is why it survived until a real 4:3 camera photo hit the tile path.

## Why existing coverage missed it
- The manual sample's "EXIF 90°" entry was only ever eyeballed at fit-view, which renders the (correct) preview — tiles only activate on zoom.
- `ExifUtilsTest` was written from the implementation output and asserted raw rects that lie **outside the image bounds** (e.g. `top=1544, bottom=1800` on a 1200px-tall raw image), so it was green while wrong.

## Tests
- Rewrote `ExifUtilsTest` from rotation geometry (no longer copies the implementation). Covers all 8 EXIF orientations with absolute literals, adds square-image cases, and asserts an in-bounds + well-formed invariant on every remapped rect — this invariant directly catches the original out-of-bounds symptom.
- Verified on device (Samsung SM-G977N, 4032×3024 / orientation 6): seam gone after the fix.
- Full `:tessera-core:testDebugUnitTest` green (189 tests), stable across repeated runs.

## Second commit (test stability)
Found and fixed an unrelated flaky test while verifying: `TesseraGestureTest.setUpContent` only called `waitForIdle()`, which doesn't wait for the async decode on `Dispatchers.IO`, so `isReady` assertions could race. Now polls `waitUntil { isReady }` (10s) when a viewerState is provided.

Closes #54
